### PR TITLE
Fix assertion error message

### DIFF
--- a/packages/@glimmer/application/src/environment.ts
+++ b/packages/@glimmer/application/src/environment.ts
@@ -44,7 +44,7 @@ class CompileTimeLookup implements ICompileTimeLookup<Specifier> {
   private getComponentDefinition(handle: number): ComponentDefinition {
     let spec = this.resolver.resolve<Option<ComponentDefinition>>(handle);
 
-    assert(!!spec, `Couldn't find a template named ${name}`);
+    assert(!!spec, `Couldn't find a template for ${handle}`);
 
     return spec!;
   }


### PR DESCRIPTION
The message is referring to a variable that was renamed. It happens to work in the browser because of `window.name` but is crashing the server.