### PR TITLE
Fix incompatibility with {{each}} and frozen objects

### DIFF
--- a/packages/@glimmer/application-test-helpers/package.json
+++ b/packages/@glimmer/application-test-helpers/package.json
@@ -19,7 +19,6 @@
     "@glimmer/di": "^0.1.9",
     "@glimmer/env": "^0.1.7",
     "@glimmer/interfaces": "^0.29.8",
-    "@glimmer/object-reference": "^0.29.8",
     "@glimmer/reference": "^0.29.8",
     "@glimmer/resolver": "^0.3.0",
     "@glimmer/runtime": "^0.29.8",

--- a/packages/@glimmer/application/package.json
+++ b/packages/@glimmer/application/package.json
@@ -19,7 +19,6 @@
     "@glimmer/di": "^0.1.9",
     "@glimmer/env": "^0.1.7",
     "@glimmer/interfaces": "^0.29.8",
-    "@glimmer/object-reference": "^0.29.8",
     "@glimmer/opcode-compiler": "^0.29.8",
     "@glimmer/reference": "^0.29.8",
     "@glimmer/resolver": "^0.3.0",

--- a/packages/@glimmer/application/src/iterable.ts
+++ b/packages/@glimmer/application/src/iterable.ts
@@ -12,7 +12,7 @@ import {
 
 import {
   UpdatableReference
-} from "@glimmer/object-reference";
+} from "@glimmer/component";
 
 export type KeyFor<T> = (item: Opaque, index: T) => string;
 

--- a/packages/@glimmer/application/test/each-test.ts
+++ b/packages/@glimmer/application/test/each-test.ts
@@ -1,0 +1,76 @@
+import { buildApp, didRender } from '@glimmer/application-test-helpers';
+import Component from '@glimmer/component';
+
+const { module, test } = QUnit;
+
+module('[@glimmer/application] each helper');
+
+function freeze<T>(array: T[]): ReadonlyArray<Readonly<T>> {
+  return Object.freeze(array.slice().map(Object.freeze));
+}
+
+class HelloWorld extends Component {
+  numbers = [1, 2, 3];
+  frozenNumbers = freeze(this.numbers);
+  strings = ["Toran", "Robert", "Jesper"];
+  frozenStrings = freeze(this.strings);
+  objects = this.strings.map(name => ({ name }));
+  frozenObjects = freeze(this.objects);
+}
+
+['numbers', 'frozenNumbers'].forEach((kind: string) => {
+  test(`renders number literals - ${kind}`, async function(assert) {
+    assert.expect(1);
+
+    let containerElement = document.createElement('div');
+
+    let app = buildApp()
+      .template('HelloWorld', `<ul>{{#each ${kind} key="@index" as |item|}}<li>{{item}}</li>{{/each}}</ul>`)
+      .component('HelloWorld', HelloWorld)
+      .boot();
+
+    app.renderComponent('HelloWorld', containerElement);
+
+    await didRender(app);
+
+    assert.equal(containerElement.innerHTML, '<ul><li>1</li><li>2</li><li>3</li></ul>');
+  });
+});
+
+['strings', 'frozenStrings'].forEach((kind: string) => {
+  test(`renders string literals - ${kind}`, async function(assert) {
+    assert.expect(1);
+
+    let containerElement = document.createElement('div');
+
+    let app = buildApp()
+      .template('HelloWorld', `<ul>{{#each ${kind} key="@index" as |item|}}<li>{{item}}</li>{{/each}}</ul>`)
+      .component('HelloWorld', HelloWorld)
+      .boot();
+
+    app.renderComponent('HelloWorld', containerElement);
+
+    await didRender(app);
+
+    assert.equal(containerElement.innerHTML, '<ul><li>Toran</li><li>Robert</li><li>Jesper</li></ul>');
+  });
+});
+
+['objects', 'frozenObjects'].forEach((kind: string) => {
+  test(`renders objects - ${kind}`, async function(assert) {
+    assert.expect(1);
+
+    let containerElement = document.createElement('div');
+
+    let app = buildApp()
+      .template('HelloWorld', `<ul>{{#each ${kind} key="@index" as |item|}}<li>{{item.name}}</li>{{/each}}</ul>`)
+      .component('HelloWorld', HelloWorld)
+      .boot();
+
+    app.renderComponent('HelloWorld', containerElement);
+
+    await didRender(app);
+
+    assert.equal(containerElement.innerHTML, '<ul><li>Toran</li><li>Robert</li><li>Jesper</li></ul>');
+  });
+});

--- a/packages/@glimmer/component/index.ts
+++ b/packages/@glimmer/component/index.ts
@@ -1,6 +1,7 @@
-export { default, ComponentFactory } from "./src/component";
-export { default as ComponentDefinition } from "./src/component-definition";
-export { default as ComponentManager } from "./src/component-manager";
-export { tracked, setPropertyDidChange, tagForProperty, UntrackedPropertyError } from "./src/tracked";
+export { default, ComponentFactory } from './src/component';
+export { default as ComponentDefinition } from './src/component-definition';
+export { default as ComponentManager } from './src/component-manager';
+export { tracked, setPropertyDidChange, tagForProperty, UntrackedPropertyError } from './src/tracked';
+export { RootReference, CachedReference, UpdatableReference, ConditionalReference } from './src/references';
 export { default as TemplateMeta } from './src/template-meta';
 export { default as Bounds } from './src/bounds';

--- a/packages/@glimmer/component/test/tracked-property-test.ts
+++ b/packages/@glimmer/component/test/tracked-property-test.ts
@@ -77,6 +77,39 @@ test('can request a tag for non-objects and get a CONSTANT_TAG', (assert) => {
   assert.ok(tagForProperty('hello world', 'foo').validate(snapshot));
 });
 
+test('can request a tag from a frozen objects', assert => {
+  class TrackedPerson {
+    @tracked firstName = 'Toran';
+  }
+
+  let obj = Object.freeze(new TrackedPerson());
+  assert.strictEqual(obj.firstName, 'Toran');
+
+  let tag = tagForProperty(obj, 'firstName');
+  let snapshot = tag.value();
+  assert.ok(tag.validate(snapshot), 'tag should be valid to start');
+  snapshot = tag.value();
+  assert.strictEqual(tag.validate(snapshot), true, 'tag is still valid');
+});
+
+test('can request a tag from an instance of a frozen class', assert => {
+  class TrackedPerson {
+    @tracked firstName = 'Toran';
+  }
+
+  let FrozenTrackedPerson = Object.freeze(TrackedPerson);
+
+  let obj = Object.freeze(new FrozenTrackedPerson());
+
+  assert.strictEqual(obj.firstName, 'Toran');
+
+  let tag = tagForProperty(obj, 'firstName');
+  let snapshot = tag.value();
+  assert.ok(tag.validate(snapshot), 'tag should be valid to start');
+  snapshot = tag.value();
+  assert.strictEqual(tag.validate(snapshot), true, 'tag is still valid');
+});
+
 test('can track a computed property', (assert) => {
   let count = 0;
   let firstName = "Tom";


### PR DESCRIPTION
Prior to this commit, the Glimmer.js implementation of the VM's `Iterable` interface relied on using an `UpdatableReference` from `@glimmer/object-reference`. Unfortunately, `@glimmer/object-reference` was an experimental implementation that was never meant to be used outside an experimental context. Nonetheless, certain classes, particularly `UpdatableReference` have found their way in use throughout the system, including here and perhaps most noticeably throughout the Glimmer VM test suite. One of the shortcomings of the implementation is incompatibility with frozen objects, because it eagerly tries to store metadata on objects.

A production-ready version of the functionality in `@glimmer/object-reference` was written for tracked properties in `@glimmer/component`. Because we never made that functionality publicly available, however, people tended to just use the `object-reference` version.

This commit makes the following changes:

1. Exposes `RootReference`, `CachedReference`, `UpdatableReference` and `ConditionalReference` from `@glimmer/component`.
2. Modifies the `@glimmer/application` `Iterable` implementation to use this version of `UpdatableReference`.
3. Adds a suite of integration tests for the `{{each}}` helper, testing frozen and non-frozen variations of string literals, number literals and objects.

In the future, we are planning to move the `Reference` subclasses provided by `@glimmer/component` into `glimmer-vm` so they are both more discoverable and more easily shared across host environments, particularly Ember.js and Glimmer.js.