### PR TITLE
Restore 0.7.0 this.element behavior

### DIFF
--- a/packages/@glimmer/component/src/component-manager.ts
+++ b/packages/@glimmer/component/src/component-manager.ts
@@ -92,9 +92,7 @@ export default class ComponentManager implements IComponentManager<ComponentStat
     return new RootReference(bucket.component);
   }
 
-  didCreateElement(bucket: ComponentStateBucket, element: HTMLElement) {
-    bucket.component.element = element;
-  }
+  didCreateElement(bucket: ComponentStateBucket, element: HTMLElement) { }
 
   didRenderLayout(bucket: ComponentStateBucket, bounds: VMBounds) {
     bucket.component.bounds = new Bounds(bounds);

--- a/packages/@glimmer/component/src/component.ts
+++ b/packages/@glimmer/component/src/component.ts
@@ -1,3 +1,4 @@
+import { assert } from "@glimmer/util";
 import { metaFor } from "./tracked";
 
 export interface Bounds {
@@ -223,7 +224,11 @@ class Component {
    * You should not try to access this property until after the component's `didInsertElement()`
    * lifecycle hook is called.
    */
-  element: HTMLElement;
+  get element(): HTMLElement {
+    let { bounds } = this;
+    assert(bounds && bounds.firstNode === bounds.lastNode, `The 'element' property can only be accessed on components that contain a single root element in their template. Try using 'bounds' instead to access the first and last nodes.`);
+    return bounds.firstNode as HTMLElement;
+  }
 
   /**
    * Development-mode only name of the component, useful for debugging.

--- a/packages/@glimmer/component/test/browser/element-test.ts
+++ b/packages/@glimmer/component/test/browser/element-test.ts
@@ -1,0 +1,71 @@
+import Component from '@glimmer/component';
+import { buildApp } from '@glimmer/application-test-helpers';
+
+const { module, test } = QUnit;
+
+module('[@glimmer/component] Component Elements');
+
+test('fragments are supported', (assert) => {
+  assert.expect(2);
+
+  class Fragment extends Component {
+    showUser = true;
+
+    didInsertElement() {
+      let firstNode = this.bounds.firstNode as HTMLElement;
+      let lastNode = this.bounds.lastNode as Text;
+
+      assert.equal(firstNode.tagName, 'H1');
+      assert.equal(lastNode.textContent, 'Hello world!');
+    }
+  }
+
+  buildApp()
+    .template('Main', '<Fragment />')
+    .template('Fragment', '{{#if showUser}}<h1>User</h1>{{/if}}Hello world!')
+    .component('Fragment', Fragment)
+    .boot();
+});
+
+test('elements are supported', (assert) => {
+  assert.expect(5);
+
+  class Element extends Component {
+    showUser = true;
+
+    didInsertElement() {
+      let firstNode = this.bounds.firstNode as HTMLElement;
+      let lastNode = this.bounds.lastNode as HTMLElement;
+
+      assert.equal(this.element.tagName, 'NAV');
+      assert.equal(firstNode.tagName, 'NAV');
+      assert.equal(lastNode.tagName, 'NAV');
+      assert.strictEqual(this.element, firstNode, 'element and first node are the same');
+      assert.strictEqual(firstNode, lastNode, 'first node and last node are the same');
+    }
+  }
+
+  buildApp()
+    .template('Main', '<Element />')
+    .template('Element', '<nav>{{#if showUser}}<h1>User</h1>{{/if}}Hello world!</nav>')
+    .component('Element', Element)
+    .boot();
+});
+
+test('accessing element throws an exception if template is a fragment', (assert) => {
+  assert.expect(1);
+
+  class Fragment extends Component {
+    didInsertElement() {
+      assert.throws(() => {
+        return this.element;
+      }, /The 'element' property can only be accessed on components that contain a single root element/);
+    }
+  }
+
+  buildApp()
+    .template('Main', '<Fragment />')
+    .template('Fragment', '{{#if showUser}}<h1>User</h1>{{/if}}Hello world!')
+    .component('Fragment', Fragment)
+    .boot();
+});

--- a/packages/@glimmer/component/test/browser/lifecycle-hook-test.ts
+++ b/packages/@glimmer/component/test/browser/lifecycle-hook-test.ts
@@ -32,11 +32,11 @@ test('Lifecycle hook ordering', (assert) => {
 
   let app = buildApp()
     .template('Main', '<div><ComponentOne /></div>')
-    .template('ComponentOne', '<div ...attributes><ComponentTwo /><ComponentThree /></div>')
-    .template('ComponentTwo', '<div ...attributes><ComponentFour /><ComponentFive /></div>')
-    .template('ComponentThree', '<div ...attributes></div>')
-    .template('ComponentFour', '<div ...attributes></div>')
-    .template('ComponentFive', '<div ...attributes></div>')
+    .template('ComponentOne', '<div><ComponentTwo /><ComponentThree /></div>')
+    .template('ComponentTwo', '<div><ComponentFour /><ComponentFive /></div>')
+    .template('ComponentThree', '<div></div>')
+    .template('ComponentFour', '<div></div>')
+    .template('ComponentFive', '<div></div>')
     .component('ComponentOne', Component1)
     .component('ComponentTwo', Component2)
     .component('ComponentThree', Component3)
@@ -58,8 +58,27 @@ test('Lifecycle hook ordering', (assert) => {
   assert.ok(didCallWillDestroy);
 });
 
-test('component element bounds are set', assert => {
-  class BoundsComponent extends Component {
+test('element is set before didInsertElement', assert => {
+  assert.expect(1);
+
+  class Element extends Component {
+    didInsertElement() {
+      assert.equal(this.element.tagName, 'H1');
+    }
+  }
+
+  buildApp()
+    .component('Element', Element)
+    .template('Main', '<Element />')
+    .template('Element', trim(`
+      <h1>Chad Hietala - Greatest thinker of our generation</h1>
+     `)).boot();
+});
+
+test('fragment bounds are set before didInsertElement', assert => {
+  assert.expect(2);
+
+  class Fragment extends Component {
     didInsertElement() {
       assert.equal(this.bounds.firstNode.nodeName, '#text', 'firstNode should be a text node');
       assert.equal(this.bounds.lastNode.textContent, 'Greatest thinker of our generation', 'last node should be a span');
@@ -67,33 +86,13 @@ test('component element bounds are set', assert => {
   }
 
   buildApp()
-    .component('BoundsComponent', BoundsComponent)
-    .template('Main', '<BoundsComponent />')
-    .template('BoundsComponent', trim(`
+    .component('Fragment', Fragment)
+    .template('Main', '<Fragment />')
+    .template('Fragment', trim(`
       Hello world!
       <h1>Chad Hietala</h1>
       <span>Greatest thinker of our generation</span>
      `)).boot();
-});
-
-test('component element is set to element with ...attributes', assert => {
-  class SplatElementComponent extends Component {
-    didInsertElement() {
-      assert.equal(this.element.textContent, 'Chad Hietala', 'component element should be splatted h1');
-      assert.equal(this.bounds.firstNode.nodeName, '#text', 'firstNode should be a text node');
-      assert.equal(this.bounds.lastNode.textContent, 'Greatest thinker of our generation', 'last node should be a span');
-    }
-  }
-
-  buildApp()
-    .component('SplatElementComponent', SplatElementComponent)
-    .template('Main', '<SplatElementComponent />')
-    .template('SplatElementComponent', trim(`
-      Hello world!
-      <h1 ...attributes>Chad Hietala</h1>
-      <span>Greatest thinker of our generation</span>
-     `)).boot();
-
 });
 
 function trim(str) {


### PR DESCRIPTION
In #19, we added support for `this.bounds` on a component, which allows accessing the first and last nodes of "fragment" templates, i.e. templates without a single root element.

One of the changes in that PR was to how `this.element` works. Instead of `this.element` meaning the root element, it instead meant the attribute with the `...attributes` annotation. Templates without `...attributes` on an element would not have `this.element` set to anything.

In retrospect, this change may have been premature. We do not yet have consensus around the exact semantics of `...attributes`. For example, can you have multiple elements with `...attributes`? In that case, a single property doesn't make sense as the API for accessing the "splattributes" elements.

In order to ease migration from 0.7.x to 0.8.0 for existing Glimmer.js apps, this PR reverts this specific behavior and restores the meaning of `this.element` to be the same as in previous versions: `this.element` is the root element.

Because fragment templates were previously unsupported, there is a small change to behavior. Now, if a fragment component accesses `this.element`, an exception will be thrown with a suggestion to use `this.bounds` instead. This shouldn't affect existing apps because fragment templates would not have compiled. Instead, this is designed to catch errors where users don't realize that a component has multiple root elements.