### PR TITLE
Better missing component error

### DIFF
--- a/packages/@glimmer/application-test-helpers/src/did-render.ts
+++ b/packages/@glimmer/application-test-helpers/src/did-render.ts
@@ -1,10 +1,12 @@
 async function didRender(app: any): Promise<void> {
-  return new Promise<void>(resolve => {
-    let watcher = setInterval(function() {
-      if (app['_rendering']) return;
-      clearInterval(watcher);
+  return new Promise<void>((resolve, reject) => {
+    // If the app is scheduled to re-render, or has not yet been rendered for
+    // the first time, register to be notified when the next render completes.
+    if (app['_scheduled'] || !app['_rendered']) {
+      app['_notifiers'].push([resolve, reject]);
+    } else {
       resolve();
-    }, 10);
+    }
   });
 };
 

--- a/packages/@glimmer/application/src/runtime-resolver.ts
+++ b/packages/@glimmer/application/src/runtime-resolver.ts
@@ -8,9 +8,7 @@ import {
   Arguments
 } from '@glimmer/runtime';
 import { TemplateOptions } from '@glimmer/opcode-compiler';
-import {
-  unwrap
-} from "@glimmer/util";
+import { expect } from "@glimmer/util";
 import { TypedRegistry } from "./typed-registry";
 import { Opaque, RuntimeResolver as IRuntimeResolver, Option, Maybe, Dict } from "@glimmer/interfaces";
 import { Owner } from "@glimmer/di";
@@ -165,7 +163,7 @@ export class RuntimeResolver implements IRuntimeResolver<Specifier> {
   lookupComponent(name: string, meta: Specifier): ComponentDefinition {
     let handle: number;
     if (!this.cache.component.hasName(name)) {
-      let specifier = unwrap(this.identifyComponent(name, meta));
+      let specifier = expect(this.identifyComponent(name, meta), `Could not find the component '${name}'`);
       let template = this.owner.lookup('template', specifier);
       let componentSpecifier = this.owner.identify('component', specifier);
       let componentFactory: ComponentFactory = null;

--- a/packages/@glimmer/application/test/browser/render-component-test.ts
+++ b/packages/@glimmer/application/test/browser/render-component-test.ts
@@ -1,4 +1,5 @@
 import { buildApp, didRender } from '@glimmer/application-test-helpers';
+import { DEBUG } from '@glimmer/env';
 
 const { module, test } = QUnit;
 
@@ -126,3 +127,33 @@ test('renders multiple components in the same container in particular places', a
 
   assert.equal(containerElement.innerHTML, '<h1>Hello Robbie!</h1><aside></aside><h1>Hello Glimmer!</h1>');
 });
+
+if (DEBUG) {
+  test('throws an exception if an invoked component is not found', async function(assert) {
+    assert.expect(1);
+
+    let containerElement = document.createElement('div');
+
+    let app = buildApp()
+      .template('HelloWorld', `<NonExistent />`)
+      .boot();
+
+    app.renderComponent('HelloWorld', containerElement);
+
+    await rejects(assert, didRender(app), /Could not find the component 'NonExistent'/);
+  });
+}
+
+async function rejects(assert: Assert, promise: Promise<any>, message: RegExp) {
+  try {
+    let value = await promise;
+    assert.ok(false, `Expected promise to reject, got ${value}`);
+  } catch (err) {
+    assert.pushResult({
+      result: err.message.match(message),
+      actual: err.message,
+      expected: message,
+      message: 'Expected error message to match'
+    });
+  }
+}


### PR DESCRIPTION
Today's error message when an invoked component can't be found is unhelpful. This PR gives a more helpful error message that includes the name of the invoked component.

As a bonus, this PR also addresses some surprisingly bad shortcomings in the implementation of the `didRender` helper:

1. Errors during render now cause the `didRender` promise to reject, whereas before errors were swallowed and the promise would never resolve nor reject.
2. Rather than relying on polling the state of the application, which is non-deterministic, we register a "notifier" that resolves or rejects the `didRender` promise as appropriate, deterministically on the next render or re-render.