### PR TITLE
Introduce Builders

### DIFF
--- a/packages/@glimmer/application/src/builders/dom-builder.ts
+++ b/packages/@glimmer/application/src/builders/dom-builder.ts
@@ -1,4 +1,4 @@
-import { Cursor, NewElementBuilder, Environment } from "@glimmer/runtime";
+import { Cursor, clientBuilder, Environment, ElementBuilder } from "@glimmer/runtime";
 import { Builder } from "../application";
 
 export default class DOMBuilder implements Builder {
@@ -8,7 +8,7 @@ export default class DOMBuilder implements Builder {
     this.cursor = { element, nextSibling };
   }
 
-  getBuilder(env: Environment) {
-    return NewElementBuilder.forInitialRender(env, this.cursor);
+  getBuilder(env: Environment): ElementBuilder {
+    return clientBuilder(env, this.cursor);
   }
 }

--- a/packages/@glimmer/application/src/builders/rehydrating-builder.ts
+++ b/packages/@glimmer/application/src/builders/rehydrating-builder.ts
@@ -1,0 +1,8 @@
+import DOMBuilder from './dom-builder';
+import { rehydrationBuilder, Environment, ElementBuilder } from '@glimmer/runtime';
+
+export default class RehydratingBuilder extends DOMBuilder {
+  getBuilder(env: Environment): ElementBuilder {
+    return rehydrationBuilder(env, this.cursor);
+  }
+}

--- a/packages/@glimmer/ssr/index.ts
+++ b/packages/@glimmer/ssr/index.ts
@@ -1,0 +1,2 @@
+export { default as StringBuilder } from './src/string-builder';
+export { default as SerializingBuilder } from './src/serializing-builder';

--- a/packages/@glimmer/ssr/package.json
+++ b/packages/@glimmer/ssr/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@glimmer/ssr",
+  "version": "0.9.0-alpha.1",
+  "description": "Server-side rendering for Glimmer Applications",
+  "repository": "https://github.com/glimmerjs/glimmer.js",
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/commonjs/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
+  "types": "dist/types/index.d.ts",
+  "dependencies": {
+    "@glimmer/application": "^0.9.0-alpha.1",
+    "@glimmer/node": "^0.29.9",
+    "@glimmer/runtime": "^0.29.9"
+  }
+}

--- a/packages/@glimmer/ssr/src/serializing-builder.ts
+++ b/packages/@glimmer/ssr/src/serializing-builder.ts
@@ -1,0 +1,9 @@
+import { DOMBuilder } from '@glimmer/application';
+import { Environment, ElementBuilder } from '@glimmer/runtime';
+import { serializeBuilder } from '@glimmer/node';
+
+export default class SerializingBuilder extends DOMBuilder {
+  getBuilder(env: Environment): ElementBuilder {
+    return serializeBuilder(env, this.cursor);
+  }
+}

--- a/packages/@glimmer/ssr/src/string-builder.ts
+++ b/packages/@glimmer/ssr/src/string-builder.ts
@@ -1,0 +1,2 @@
+import { DOMBuilder } from '@glimmer/application';
+export default class StringBuilder extends DOMBuilder {}


### PR DESCRIPTION
This introduces the builders required for rendering in rehydration, serialization, and string modes. Rehydration and serialization are implicitly coupled to one another, in that serialization is the producer of the rehydration format and the rehydrating builder consumes it. String mode is just the normal dom builder but has the implicit dependency on being passed a Simple-DOM document.