### PR TITLE
Optimize template-only components

### DIFF
--- a/packages/@glimmer/application/src/loaders/runtime-compiler/resolver.ts
+++ b/packages/@glimmer/application/src/loaders/runtime-compiler/resolver.ts
@@ -171,12 +171,6 @@ export default class RuntimeResolver implements IRuntimeResolver<Specifier> {
 
       if (componentSpecifier !== undefined) {
         componentFactory = this.owner.factoryFor(componentSpecifier);
-      } else {
-        componentFactory = {
-          create(injections) {
-            return Component.create(injections);
-          }
-        };
       }
 
       handle = this.registerComponent(name, specifier, componentFactory, template);

--- a/packages/@glimmer/component/src/component-manager.ts
+++ b/packages/@glimmer/component/src/component-manager.ts
@@ -16,12 +16,13 @@ import {
 import { Dict, Destroyable, Opaque, Option } from "@glimmer/util";
 import { Tag } from "@glimmer/reference";
 import { RuntimeResolver, ComponentCapabilities, Recast, VMHandle } from "@glimmer/interfaces";
-import { VersionedPathReference } from '@glimmer/reference';
+import { VersionedPathReference, PathReference, CONSTANT_TAG } from '@glimmer/reference';
+import { DEBUG } from '@glimmer/env';
 
 import Component from "./component";
 import Bounds from './bounds';
 import { DefinitionState } from "./component-definition";
-import { RootReference } from "./references";
+import { RootReference, TemplateOnlyComponentDebugReference } from "./references";
 
 export interface ConstructorOptions {
   env: Environment;
@@ -58,11 +59,28 @@ export class ComponentStateBucket {
   }
 }
 
+const EMPTY_SELF = new RootReference(null);
+
+/**
+ * For performance reasons, we want to avoid instantiating component buckets for
+ * components that don't have an associated component class that we would need
+ * instantiate and invoke lifecycle hooks on.
+ *
+ * In development mode, however, we need to track some state about the component
+ * in order to produce more useful error messages. This
+ * TemplateOnlyComponentDebugBucket is only created in development mode to hold
+ * that state.
+ */
+export class TemplateOnlyComponentDebugBucket {
+  constructor(public definition: DefinitionState) {
+  }
+}
+
 export interface CompilableRuntimeResolver extends RuntimeResolver<Opaque> {
   compileTemplate(name: string, layout: Option<number>): Invocation;
 }
 
-export default class ComponentManager implements IComponentManager<ComponentStateBucket, DefinitionState>, WithStaticLayout<ComponentStateBucket, DefinitionState, Opaque, CompilableRuntimeResolver> {
+export default class ComponentManager implements IComponentManager<ComponentStateBucket | TemplateOnlyComponentDebugBucket | void, DefinitionState>, WithStaticLayout<ComponentStateBucket | TemplateOnlyComponentDebugBucket | void, DefinitionState, Opaque, CompilableRuntimeResolver> {
   private env: Environment;
 
   static create(options: ConstructorOptions): ComponentManager {
@@ -92,51 +110,73 @@ export default class ComponentManager implements IComponentManager<ComponentStat
     return resolver.compileTemplate(name, handle as Recast<VMHandle, number>);
   }
 
-  create(_env: Environment, definition: DefinitionState, args: Arguments, _dynamicScope: DynamicScope, _caller: VersionedPathReference<Opaque>, _hasDefaultBlock: boolean): ComponentStateBucket {
-    let owner = getOwner(this.env);
-    return new ComponentStateBucket(definition, args.capture(), owner);
+  create(_env: Environment, definition: DefinitionState, args: Arguments, _dynamicScope: DynamicScope, _caller: VersionedPathReference<Opaque>, _hasDefaultBlock: boolean): TemplateOnlyComponentDebugBucket | ComponentStateBucket | void {
+    // In development mode, if a component is template-only, save off state
+    // needed for error messages. This will get stripped in production mode and
+    // no bucket will be instantiated.
+    if (DEBUG && !definition.ComponentClass) {
+      return new TemplateOnlyComponentDebugBucket(definition);
+    }
+
+    // Only create a state bucket if the component is actually stateful. We can
+    // skip this for template-only components, which are pure functions.
+    if (definition.ComponentClass) {
+      let owner = getOwner(this.env);
+      return new ComponentStateBucket(definition, args.capture(), owner);
+    }
   }
 
-  getSelf(bucket: ComponentStateBucket): RootReference {
-    return new RootReference(bucket.component);
+  getSelf(bucket: ComponentStateBucket): PathReference {
+    if (DEBUG && bucket instanceof TemplateOnlyComponentDebugBucket) {
+      return new TemplateOnlyComponentDebugReference(bucket.definition.name);
+    }
+    if (bucket) {
+      return new RootReference(bucket.component);
+    }
+    return EMPTY_SELF;
   }
 
   didCreateElement(bucket: ComponentStateBucket, element: HTMLElement) { }
 
   didRenderLayout(bucket: ComponentStateBucket, bounds: VMBounds) {
-    if (bucket.component) {
-      bucket.component.bounds = new Bounds(bounds);
-    }
+    if (DEBUG && bucket instanceof TemplateOnlyComponentDebugBucket) { return; }
+    if (!bucket) { return; }
+    bucket.component.bounds = new Bounds(bounds);
   }
 
   didCreate(bucket: ComponentStateBucket) {
-    if (bucket && bucket.component) { bucket.component.didInsertElement(); }
+    if (DEBUG && bucket instanceof TemplateOnlyComponentDebugBucket) { return; }
+    if (!bucket) { return; }
+    bucket.component.didInsertElement();
   }
 
-  getTag({ tag }: ComponentStateBucket): Tag {
-    return tag;
+  getTag(bucket: ComponentStateBucket): Tag {
+    if (DEBUG && bucket instanceof TemplateOnlyComponentDebugBucket) { return CONSTANT_TAG; }
+    if (!bucket) { return CONSTANT_TAG; }
+    return bucket.tag;
   }
 
   update(bucket: ComponentStateBucket, scope: DynamicScope) {
-    if (bucket && bucket.component) {
-      bucket.component.args = bucket.namedArgsSnapshot();
-    }
+    if (DEBUG && bucket instanceof TemplateOnlyComponentDebugBucket) { return; }
+    if (!bucket) { return; }
+
+    bucket.component.args = bucket.namedArgsSnapshot();
   }
 
   didUpdateLayout() {}
 
-  didUpdate({ component }: ComponentStateBucket) {
-    if (component) {
-      component.didUpdate();
-    }
+  didUpdate(bucket: ComponentStateBucket) {
+    if (DEBUG && bucket instanceof TemplateOnlyComponentDebugBucket) { return; }
+    if (!bucket) { return; }
+
+    bucket.component.didUpdate();
   }
 
   getDestructor(bucket: ComponentStateBucket): Destroyable {
-    if (bucket.component) {
-      return bucket.component;
-    }
+    if (DEBUG && bucket instanceof TemplateOnlyComponentDebugBucket) { return NOOP_DESTROYABLE; }
+    if (!bucket) { return NOOP_DESTROYABLE; }
 
-    return NOOP_DESTROYABLE;
+    return bucket.component;
   }
 }
 

--- a/packages/@glimmer/component/src/references.ts
+++ b/packages/@glimmer/component/src/references.ts
@@ -1,5 +1,5 @@
 import {
-  dict
+  dict, Opaque
 } from "@glimmer/util";
 import {
   PathReference,
@@ -167,3 +167,13 @@ export class ConditionalReference extends GlimmerConditionalReference {
     return new ConditionalReference(reference);
   }
 }
+
+export class TemplateOnlyComponentDebugReference extends ConstReference<void> {
+  constructor(protected name: string) {
+    super(undefined);
+  }
+
+  get(propertyKey: string): PathReference<Opaque> {
+    throw new Error(`You tried to reference {{${propertyKey}}} from the ${this.name} template, which doesn't have an associated component class. Template-only components can only access args passed to them. Did you mean {{@${propertyKey}}}?`);
+  }
+};


### PR DESCRIPTION
One of the benefits of template-only components is that they are stateless "pure functions": they operate only on the arguments passed to them. That means that the normal work we have to do around managing state and lifecycle for stateful components can be skipped in template-only components.

Previously, we were instantiating two useless objects per pure component:

1. An empty base Component class (why????)
2. A ComponentStateBucket, which tracks metadata about a particular component instance

In this commit, we instead only instantiate a component and ComponentStateBucket in cases where the user has supplied a Component subclass. In addition to skipping extra allocations, this allows us to bail out early in cases where we do not need to invoke component lifecycle hooks.

As an additional optimization, we can return a single instance of CONSTANT_TAG from getTag(), and return a shared instance of a null ConstReference from getSelf(), reducing the allocations required by stateless components even further and avoiding an opcode execution on updates altogether due to the CONSTANT_TAG.

This commit also addresses a polish/DX issue where component-less templates would produce an opaque error if a developer tried to access properties from the template. Now, accessing a property like `{{foo}}` from a template without a backing component produces a helpful error message suggesting the user may have meant to access a passed argument instead.

In order to produce this error message, we have to allocate a debug-only state bucket for each component instance in development mode that contains information about the invoked template. That means that the above-described optimizations only kick in in production mode, but it didn't seem worth sacrificing helpful error messages. This difference between development mode and production mode leads to some unfortunate boilerplate in order to produce something that will be stripped appropriately, but I couldn't find a better way to do it without sacrificing code size or performance.