### PR TITLE
Add more tests for 3rd party builtins

### DIFF
--- a/packages/@glimmer/compiler-delegates/package-lock.json
+++ b/packages/@glimmer/compiler-delegates/package-lock.json
@@ -1,0 +1,612 @@
+{
+  "name": "@glimmer/compiler-delegates",
+  "version": "0.9.0-alpha.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@glimmer/bundle-compiler": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/bundle-compiler/-/bundle-compiler-0.29.10.tgz",
+      "integrity": "sha512-PcdN5M4ghwMaaFhkuSs6MBdhclAbud/MT4GaiEUAQzTlEdTddrXbBNR3SXkhPc/0K1De7pNmu7CMTSTFDLegTQ==",
+      "requires": {
+        "@glimmer/compiler": "0.29.10",
+        "@glimmer/interfaces": "0.29.10",
+        "@glimmer/opcode-compiler": "0.29.10",
+        "@glimmer/program": "0.29.10",
+        "@glimmer/syntax": "0.29.10",
+        "@glimmer/util": "0.29.10",
+        "@glimmer/wire-format": "0.29.10",
+        "simple-html-tokenizer": "0.4.3"
+      }
+    },
+    "@glimmer/compiler": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.29.10.tgz",
+      "integrity": "sha512-hxhGRDaMg3gtPCRDKZDhb15op2d9rwDMCE/IamlbmMuAIkMpB/k3FXXG0qaSk4pUpnoZsrMwRaSbzahPccnP7Q==",
+      "requires": {
+        "@glimmer/interfaces": "0.29.10",
+        "@glimmer/syntax": "0.29.10",
+        "@glimmer/util": "0.29.10",
+        "@glimmer/wire-format": "0.29.10",
+        "simple-html-tokenizer": "0.4.3"
+      }
+    },
+    "@glimmer/component": {
+      "version": "0.9.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@glimmer/component/-/component-0.9.0-alpha.4.tgz",
+      "integrity": "sha512-hWre0VcOOWDe6m1gHZL01PTKj/PAcUAJ1jxhFnoS2BX6CcFzQi9iyMeWmTDiQOzg+uMhUsj+OQ7aG+NHOeXJtg==",
+      "requires": {
+        "@glimmer/di": "0.1.11",
+        "@glimmer/env": "0.1.7",
+        "@glimmer/reference": "0.29.10",
+        "@glimmer/runtime": "0.29.10",
+        "@glimmer/util": "0.29.10"
+      }
+    },
+    "@glimmer/di": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@glimmer/di/-/di-0.1.11.tgz",
+      "integrity": "sha1-poeMB6E6LCx2/N5ZilyXY3v8QoA="
+    },
+    "@glimmer/encoder": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/encoder/-/encoder-0.29.10.tgz",
+      "integrity": "sha512-LOzhjaIq9S/w0FJH4VxRjXt+GJuvqW6Vt/ejQgL1ZYE83ApHiJ2aBCixmYSA97YHsDF80iNvT6i8E6eqSHA4tQ=="
+    },
+    "@glimmer/env": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@glimmer/env/-/env-0.1.7.tgz",
+      "integrity": "sha1-/S0rVakCnGs3psk16MiHGucN+gc="
+    },
+    "@glimmer/interfaces": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.29.10.tgz",
+      "integrity": "sha512-8GV25NxXfoVjZbNcrwtJ97FSL5d0eDWX5OJyfIjoaNtl2NCdT6jm6BeU5LNhzZH6e9awXRvX0EgVhlJKK1H5ig==",
+      "requires": {
+        "@glimmer/wire-format": "0.29.10"
+      }
+    },
+    "@glimmer/object": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/object/-/object-0.29.10.tgz",
+      "integrity": "sha512-SMvCT2caia8+pZqKMzxn40Y8xkdqpGqljt/MnTHiepOp+PNCRSAAtsT+cpIFlHsFcbj1Zd5OR4+ImmvRD7b0UA==",
+      "requires": {
+        "@glimmer/object-reference": "0.29.10",
+        "@glimmer/util": "0.29.10"
+      }
+    },
+    "@glimmer/object-reference": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/object-reference/-/object-reference-0.29.10.tgz",
+      "integrity": "sha512-3p7zLcWZ9t/DO4MSsv5B4c50ITEPd/y2vbGvhgiSQ5LGcQHtf6hjSVeKO6fV6GZYZUFeGtGbHi/MryVoA+UMCA==",
+      "requires": {
+        "@glimmer/reference": "0.29.10",
+        "@glimmer/util": "0.29.10"
+      }
+    },
+    "@glimmer/opcode-compiler": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/opcode-compiler/-/opcode-compiler-0.29.10.tgz",
+      "integrity": "sha512-hKpvjQ0Avj3MYXpxOoNUtfDIq4Xg/pQMWrVgePp3I1HID38AfS/SXyoJuAoh/Is8TH0uM56jEieU0HZ9tZDqFQ==",
+      "requires": {
+        "@glimmer/encoder": "0.29.10",
+        "@glimmer/interfaces": "0.29.10",
+        "@glimmer/program": "0.29.10",
+        "@glimmer/syntax": "0.29.10",
+        "@glimmer/util": "0.29.10",
+        "@glimmer/vm": "0.29.10",
+        "@glimmer/wire-format": "0.29.10",
+        "simple-html-tokenizer": "0.4.3"
+      }
+    },
+    "@glimmer/program": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/program/-/program-0.29.10.tgz",
+      "integrity": "sha512-gL2EW7hqdUoaomm+ykXOUtUVb1f8P3dcXvW3j0ld7aUEGbJJX6JlvvrTiFMnEIcb1Ex8gpLE7Q7opthDAkrLow==",
+      "requires": {
+        "@glimmer/encoder": "0.29.10",
+        "@glimmer/interfaces": "0.29.10",
+        "@glimmer/util": "0.29.10"
+      }
+    },
+    "@glimmer/reference": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.29.10.tgz",
+      "integrity": "sha512-Gbg6RmklzyaYNEHDRcFZxL3gGK+c8gyKLsxMhxjK/vf57s2dZ2JamSSlV3oamvExf16U8i0K1RvkpqPF9i7isA==",
+      "requires": {
+        "@glimmer/util": "0.29.10"
+      }
+    },
+    "@glimmer/resolution-map-builder": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/resolution-map-builder/-/resolution-map-builder-0.4.0.tgz",
+      "integrity": "sha1-uZm1HqMEakSzI+fvNoPCLJmAfuM=",
+      "requires": {
+        "broccoli-plugin": "1.3.0",
+        "silent-error": "1.1.0",
+        "walk-sync": "0.3.2"
+      }
+    },
+    "@glimmer/resolver": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/resolver/-/resolver-0.3.1.tgz",
+      "integrity": "sha1-QQaTRbb0G+sJSMw12OSqYK3K38U=",
+      "requires": {
+        "@glimmer/di": "0.2.0"
+      },
+      "dependencies": {
+        "@glimmer/di": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@glimmer/di/-/di-0.2.0.tgz",
+          "integrity": "sha1-c7/Upu5BSKgL8JLopdKbysnUzn4="
+        }
+      }
+    },
+    "@glimmer/runtime": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/runtime/-/runtime-0.29.10.tgz",
+      "integrity": "sha512-fyjF+ohZrf5IcTs2W5sx7e8qTw179dyiJ07BCXyaQl+ufsAIsGwusGet0JM1pV0C269H6b29cT5xD3aIBcBjBA==",
+      "requires": {
+        "@glimmer/interfaces": "0.29.10",
+        "@glimmer/object": "0.29.10",
+        "@glimmer/object-reference": "0.29.10",
+        "@glimmer/opcode-compiler": "0.29.10",
+        "@glimmer/program": "0.29.10",
+        "@glimmer/reference": "0.29.10",
+        "@glimmer/util": "0.29.10",
+        "@glimmer/vm": "0.29.10",
+        "@glimmer/wire-format": "0.29.10"
+      }
+    },
+    "@glimmer/syntax": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.29.10.tgz",
+      "integrity": "sha512-lN06OpLp4GIlacxMik5V1dy5HLvMvgZ99YjDRJcbnRMUH37UP9FkNcj0LVQBpVzmMINnXSFNPjAp9AXPAH3HTg==",
+      "requires": {
+        "@glimmer/interfaces": "0.29.10",
+        "@glimmer/util": "0.29.10",
+        "handlebars": "4.0.11",
+        "simple-html-tokenizer": "0.4.3"
+      }
+    },
+    "@glimmer/util": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.29.10.tgz",
+      "integrity": "sha512-GeH7OuD3wZWnLXSUoyIym5/Ab541r+eWzY6bF4HeT0QzmnVA1oyzqIFsaR91oGxhsKPZDbzyWSQ2807cwrbp9A=="
+    },
+    "@glimmer/vm": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/vm/-/vm-0.29.10.tgz",
+      "integrity": "sha512-fBrILZwhb6FEpCfYUhpQr/LwP27uQpC4N5EAhr17YB5jpgNh2vEn59IOs3lMsFKu2h/E/4X8rjgbvaRS1LB6mA==",
+      "requires": {
+        "@glimmer/interfaces": "0.29.10",
+        "@glimmer/program": "0.29.10",
+        "@glimmer/util": "0.29.10"
+      }
+    },
+    "@glimmer/wire-format": {
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.29.10.tgz",
+      "integrity": "sha512-EUGRWvaBKOTN+Oa02gxmqeJGR3I4hFB+IRGN2NrHswjIdoN3a9EI/0mQ8j8w9FSMgdNJoQ6MZJr8SUZTpBEwTg==",
+      "requires": {
+        "@glimmer/util": "0.29.10"
+      }
+    },
+    "@types/node": {
+      "version": "8.0.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.47.tgz",
+      "integrity": "sha512-kOwL746WVvt/9Phf6/JgX/bsGQvbrK5iUgzyfwZNcKVFcjAUVSpF9HxevLTld2SG9aywYHOILj38arDdY1r/iQ=="
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "broccoli-plugin": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
+      "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
+      "requires": {
+        "promise-map-series": "0.2.3",
+        "quick-temp": "0.1.8",
+        "rimraf": "2.6.2",
+        "symlink-or-copy": "1.1.8"
+      }
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "optional": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "optional": true
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "optional": true
+    },
+    "ensure-posix-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
+      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glimmer-analyzer": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/glimmer-analyzer/-/glimmer-analyzer-0.3.2.tgz",
+      "integrity": "sha512-A35E5b84Pao6Wu3NAm5XCVFURMKg9wFRI/j2ufYXbUYMN+KW8YRQ/fhhpD6PRI5WSy7AIUpuGthQtghoIomKEg==",
+      "requires": {
+        "@glimmer/resolution-map-builder": "0.4.0",
+        "@glimmer/resolver": "0.3.1",
+        "@glimmer/syntax": "0.29.10",
+        "debug": "3.1.0",
+        "simple-html-tokenizer": "0.4.3"
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "optional": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+    },
+    "matcher-collection": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
+      "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
+      "requires": {
+        "minimatch": "3.0.4"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+    },
+    "mktemp": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
+      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    },
+    "promise-map-series": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
+      "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+      "requires": {
+        "rsvp": "3.6.2"
+      }
+    },
+    "quick-temp": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
+      "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
+      "requires": {
+        "mktemp": "0.4.0",
+        "rimraf": "2.6.2",
+        "underscore.string": "3.3.4"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+    },
+    "silent-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.1.0.tgz",
+      "integrity": "sha1-IglwbxyFCp8dENDYQJGLRvJuG8k=",
+      "requires": {
+        "debug": "2.6.9"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "simple-html-tokenizer": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.4.3.tgz",
+      "integrity": "sha512-OpUzgR+P/Qsu6ztZehr4PxvTbV4sDW91hAqc2tnz4fjuFTqErWIUdUMbnzX+19F4IEpSSfa0vCAz5xJSs0LpPw=="
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+    },
+    "symlink-or-copy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz",
+      "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM="
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "optional": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "optional": true
+    },
+    "underscore.string": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "requires": {
+        "sprintf-js": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "walk-sync": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
+      "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
+      "requires": {
+        "ensure-posix-path": "1.0.2",
+        "matcher-collection": "1.0.5"
+      }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      }
+    }
+  }
+}

--- a/packages/@glimmer/compiler-delegates/package.json
+++ b/packages/@glimmer/compiler-delegates/package.json
@@ -7,7 +7,7 @@
   "files": [
     "dist"
   ],
-  "main": "dist/commonjs/es5/index.js",
+  "main": "dist/commonjs/es2017/index.js",
   "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "dependencies": {

--- a/packages/@glimmer/compiler-delegates/src/bundle.ts
+++ b/packages/@glimmer/compiler-delegates/src/bundle.ts
@@ -17,3 +17,13 @@ export interface BundleCompilerDelegate extends CompilerDelegate {
 export interface Builtins {
   [key: string]: Specifier;
 }
+
+export type ModulePath = string;
+export type Name = string;
+export type Identifier = string;
+
+export interface BuiltinsMap {
+  byName: Map<Name, ModulePath>;
+  byIdentifier: Map<Identifier, Specifier>;
+  byModulePath: Map<ModulePath, Name>;
+}

--- a/packages/@glimmer/compiler-delegates/src/utils/code-gen.ts
+++ b/packages/@glimmer/compiler-delegates/src/utils/code-gen.ts
@@ -1,6 +1,7 @@
 import { Specifier } from "@glimmer/bundle-compiler";
 import { dict, Dict } from "@glimmer/util";
 import { Option } from "@glimmer/interfaces";
+import { BuiltinsMap } from '../bundle';
 
 export interface OutputFiles {
   dataSegment: Option<string>;
@@ -58,16 +59,17 @@ export function getModuleSpecifier(modulePath: string) {
   return JSON.stringify(`./${modulePath}`);
 }
 
-export function getImportStatements(modules: Specifier[], builtins: Dict<string>) {
+export function getImportStatements(modules: Specifier[], builtins: BuiltinsMap) {
   let identifiers = new Array<string>(modules.length).fill('');
   let seen = dict<boolean>();
 
   let imports = modules.map((specifier, i) => {
     let { module, name } = specifier;
 
-    if (name in builtins) {
-      identifiers[i] = name;
-      return `import { ${name} } from "${module}";`;
+    if (builtins.byModulePath.has(module)) {
+      let id = `${name}_${i}`;
+      identifiers[i] = id;
+      return `import { ${name} as ${id} } from "${module}";`;
     }
 
     let id = getIdentifier(module, seen);


### PR DESCRIPTION
This fixes some issues where the import generation of the module table would have the incorrect output due to the fact that we need to actually check the identity of the contents of the specifier in several different ways. This also makes sure that we only import helpers once even if there are multiple invocations.