### PR TITLE
Implement Main Invocation For Bytecode Loader

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "**/node_modules": true,
     "**/bower_components": true,
     "dist": true
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/@glimmer/app-compiler/src/bundle-compiler.ts
+++ b/packages/@glimmer/app-compiler/src/bundle-compiler.ts
@@ -82,7 +82,7 @@ export default class GlimmerBundleCompiler extends Plugin {
 
     let { outputPath } = this;
 
-    let locator = this.delegate.templateLocatorFor({ module: 'main', name: 'mainTemplate' });
+    let locator = this.delegate.templateLocatorFor({ module: '@glimmer/application', name: 'mainTemplate' });
     let compilable = CompilableTemplate.topLevel(JSON.parse(mainTemplate.block), this.compiler.compileOptions(locator));
 
     this.compiler.addCompilableTemplate(locator, compilable);

--- a/packages/@glimmer/application-test-helpers/index.ts
+++ b/packages/@glimmer/application-test-helpers/index.ts
@@ -1,4 +1,5 @@
 export * from './src/app-builder';
 export * from './src/compiler';
+export * from './src/render-test';
 export { default as defaultResolverConfiguration } from './src/default-resolver-configuration';
 export { default as didRender } from './src/did-render';

--- a/packages/@glimmer/application-test-helpers/src/app-builder.ts
+++ b/packages/@glimmer/application-test-helpers/src/app-builder.ts
@@ -102,10 +102,10 @@ export class AppBuilder<T extends TestApplication> {
     let delegate = new CompilerDelegate(resolver);
     let compiler = new BundleCompiler(delegate);
     let mainTemplateSingleRoot = precompile('{{component @componentName.componentName model=@model.model}}', {
-      meta: { specifier: 'fuck' }
+      meta: { specifier: 'mainTemplate' }
     });
 
-    let mainLocator = locatorFor(mainTemplateSingleRoot.meta, 'default');
+    let mainLocator = locatorFor(mainTemplateSingleRoot.meta.specifier, 'default');
     mainLocator.meta.locator = mainLocator;
 
     let compilableTemplate = CompilableTemplate.topLevel(JSON.parse(mainTemplateSingleRoot.block), compiler.compileOptions(mainLocator));
@@ -129,9 +129,9 @@ export class AppBuilder<T extends TestApplication> {
       resolverSymbols[locator.module] = template.symbolTable;
     });
 
-    table.byHandle.forEach((locator, handle) => {
-      resolverTable[handle] = locator;
-    });
+    // table.byHandle.forEach((locator, handle) => {
+    //   resolverTable[handle] = this.modules[locator.module;
+    // });
 
     let bytecode = heap.buffer;
     let data = {
@@ -168,7 +168,7 @@ export class AppBuilder<T extends TestApplication> {
     }
 
     let doc: Document = this.options.document as Document || document;
-    let element = doc.body;
+    let element = doc.getElementById('qunit-fixture');
     let cursor = new Cursor(element, null);
     let builder = new DOMBuilder(cursor);
     let renderer = new SyncRenderer();
@@ -183,9 +183,8 @@ export class AppBuilder<T extends TestApplication> {
       document: this.options.document
     });
 
-    let rootElement = doc.createElement('div');
-    app.rootElement = rootElement;
-    app.renderComponent('Main', rootElement);
+    app.rootElement = element;
+    app.renderComponent('Main', {});
 
     await app.boot();
 

--- a/packages/@glimmer/application-test-helpers/src/app-builder.ts
+++ b/packages/@glimmer/application-test-helpers/src/app-builder.ts
@@ -137,7 +137,7 @@ export class AppBuilder<T extends TestApplication> {
       table: resolverTable,
       map: resolverMap,
       symbols: resolverSymbols,
-      mainSpecifier: mainLocator.module,
+      mainSpec: { specifier: 'mainTemplate' },
       heap: {
         table: heap.table,
         handle: heap.handle

--- a/packages/@glimmer/application-test-helpers/src/app-builder.ts
+++ b/packages/@glimmer/application-test-helpers/src/app-builder.ts
@@ -2,7 +2,7 @@ import {
   Simple
 } from '@glimmer/interfaces';
 import Resolver, { BasicModuleRegistry, ResolverConfiguration } from '@glimmer/resolver';
-import { Opaque, Dict, ProgramSymbolTable } from '@glimmer/interfaces';
+import { Opaque, Dict, ProgramSymbolTable, ComponentCapabilities } from '@glimmer/interfaces';
 import { FactoryDefinition } from '@glimmer/di';
 import defaultResolverConfiguration from './default-resolver-configuration';
 import { precompile } from './compiler';
@@ -137,6 +137,7 @@ export class AppBuilder<T extends TestApplication> {
       table: resolverTable,
       map: resolverMap,
       symbols: resolverSymbols,
+      mainSpecifier: mainLocator.module,
       heap: {
         table: heap.table,
         handle: heap.handle
@@ -186,7 +187,7 @@ export class AppBuilder<T extends TestApplication> {
   }
 }
 
-class CompilerDelegate implements ICompilerDelegate<AppBuilderTemplateMeta> {
+export class CompilerDelegate implements ICompilerDelegate<AppBuilderTemplateMeta> {
   constructor(protected resolver: Resolver) {
   }
 
@@ -199,7 +200,7 @@ class CompilerDelegate implements ICompilerDelegate<AppBuilderTemplateMeta> {
     return { module: resolved, name: 'default' };
   }
 
-  getComponentCapabilities() {
+  getComponentCapabilities(): ComponentCapabilities {
     return CAPABILITIES;
   }
 

--- a/packages/@glimmer/application-test-helpers/src/render-test.ts
+++ b/packages/@glimmer/application-test-helpers/src/render-test.ts
@@ -32,7 +32,11 @@ function isTestFunction(value: any): value is (this: RenderTest, assert: typeof 
 }
 
 export class RenderTest {
+  assert =  QUnit.assert;
   app: AppBuilder<TestApplication>;
+  assertHTML(html: string) {
+    this.assert.equal(html, document.getElementById('qunit-fixture').innerHTML);
+  }
 }
 
 function setTestingDescriptor(descriptor: PropertyDescriptor): void {

--- a/packages/@glimmer/application-test-helpers/src/render-test.ts
+++ b/packages/@glimmer/application-test-helpers/src/render-test.ts
@@ -5,17 +5,24 @@ export interface Constructor<T> {
   new (...args: any[]): T;
 }
 
-export function renderModule(name: string, renderTest: Constructor<RenderTest>) {
+export function renderModule(name: string, renderTest: Constructor<RenderTest>, options?: Object) {
   QUnit.module(name);
 
   for (let prop in renderTest.prototype) {
     const test = renderTest.prototype[prop];
 
     if (isTestFunction(test) && shouldRun(test)) {
-      ['runtime-compiler', 'bytecode'].forEach(loader => {
-        let app = buildApp({ loader });
-        QUnit.test(`[${loader}] ${prop}`, assert => test.call({ app }, assert));
-      });
+      if (options) {
+        let app = buildApp(options);
+        let instance = new renderTest(app);
+        QUnit.test(`${prop}`, assert => test.call(instance, assert));
+      } else {
+        ['runtime-compiler', 'bytecode'].forEach(loader => {
+          let app = buildApp({ loader });
+          let instance = new renderTest(app);
+          QUnit.test(`[${loader}] ${prop}`, assert => test.call(instance, assert));
+        });
+      }
     }
   }
 }
@@ -31,11 +38,33 @@ function isTestFunction(value: any): value is (this: RenderTest, assert: typeof 
   return typeof value === 'function' && value.isTest;
 }
 
+export interface RenderOptions {
+  component: string;
+  parent?: Node;
+  sibling?: Node;
+  data?: Object;
+}
+
 export class RenderTest {
   assert =  QUnit.assert;
-  app: AppBuilder<TestApplication>;
+  constructor(public app: AppBuilder<TestApplication>) {}
+  async render(options: RenderOptions) {
+    let app = await this.app.boot();
+    if (this.app.options.loader === 'bytecode') {
+      let { data, component } = options;
+      app.renderComponent({
+        component,
+        data
+      });
+    } else {
+      let { component, parent, sibling } = options;
+      app.renderComponent(component, parent, sibling);
+    }
+  }
+
   assertHTML(html: string) {
-    this.assert.equal(html, document.getElementById('qunit-fixture').innerHTML);
+    let fixture =  this.app.rootElement();
+    this.assert.equal((fixture as Element).innerHTML, html);
   }
 }
 

--- a/packages/@glimmer/application/index.ts
+++ b/packages/@glimmer/application/index.ts
@@ -20,4 +20,5 @@ export { default as AsyncRenderer } from './src/renderers/async-renderer';
 export { default as Iterable } from './src/iterable';
 export { default as buildAction, debugInfoForReference } from './src/helpers/action';
 export { default as mainTemplate } from './src/templates/main';
+export { default as mainTemplateSingleRoot } from './src/templates/main-single-root';
 export * from './src/helpers';

--- a/packages/@glimmer/application/src/loaders/bytecode/loader.ts
+++ b/packages/@glimmer/application/src/loaders/bytecode/loader.ts
@@ -15,6 +15,11 @@ export interface SerializedHeapInfos {
   handle: number;
 }
 
+export interface WTF {
+  componentName: RootReference<string>;
+  model: RootReference<Object>;
+}
+
 export interface BytecodeData {
   main: number;
   heap: SerializedHeapInfos;
@@ -48,7 +53,7 @@ export default class BytecodeLoader implements Loader {
     for (let i = 0; i <= 9; i++) { vm.stack.push(null); }
   }
 
-  loadMain(vm: LowLevelVM<Opaque>, self: RootReference<Opaque>) {
+  loadMain(vm: LowLevelVM<Opaque>, self: WTF) {
     let { map, mainSpec, symbols, main } = this.data;
     let mainSpecifier = mainSpec.specifier;
     let symbolTable = symbols[mainSpecifier];
@@ -57,7 +62,8 @@ export default class BytecodeLoader implements Loader {
 
     this.loadBlocks(vm);
 
-    vm.stack.push(self);
+    vm.stack.push(self.model);
+    vm.stack.push(self.componentName);
     ARGS.setup(vm.stack, this.getArgs(symbolTable), ['main', 'else', 'attrs'], 0, false);
     vm.stack.push(ARGS);
 

--- a/packages/@glimmer/application/src/loaders/bytecode/loader.ts
+++ b/packages/@glimmer/application/src/loaders/bytecode/loader.ts
@@ -15,11 +15,6 @@ export interface SerializedHeapInfos {
   handle: number;
 }
 
-export interface WTF {
-  componentName: RootReference<string>;
-  model: RootReference<Object>;
-}
-
 export interface BytecodeData {
   main: number;
   heap: SerializedHeapInfos;
@@ -53,7 +48,7 @@ export default class BytecodeLoader implements Loader {
     for (let i = 0; i <= 9; i++) { vm.stack.push(null); }
   }
 
-  loadMain(vm: LowLevelVM<Opaque>, self: WTF) {
+  loadMain(vm: LowLevelVM<Opaque>, self: RootReference<Opaque>) {
     let { map, mainSpec, symbols, main } = this.data;
     let mainSpecifier = mainSpec.specifier;
     let symbolTable = symbols[mainSpecifier];
@@ -62,8 +57,11 @@ export default class BytecodeLoader implements Loader {
 
     this.loadBlocks(vm);
 
-    vm.stack.push(self.model);
-    vm.stack.push(self.componentName);
+    let componentName = self.get('componentName');
+    let model = self.get('model');
+    vm.stack.push(model);
+    vm.stack.push(componentName);
+
     ARGS.setup(vm.stack, this.getArgs(symbolTable), ['main', 'else', 'attrs'], 0, false);
     vm.stack.push(ARGS);
 

--- a/packages/@glimmer/application/src/loaders/bytecode/loader.ts
+++ b/packages/@glimmer/application/src/loaders/bytecode/loader.ts
@@ -9,14 +9,12 @@ import BytecodeResolver from './resolver';
 import { PathReference } from '@glimmer/reference';
 import { SymbolTable, VMHandle, Recast } from '@glimmer/interfaces';
 
-export interface SerializedHeap {
-  table: number[];
-  handle: number;
-}
-
 export interface BytecodeData {
   main: number;
-  heap: SerializedHeap;
+  entryHandle: number;
+  nextFreeHandle: number;
+  heapTable: number[];
+  heap:  number[];
   pool: ConstantPool;
   table: Opaque[];
   map: Dict<number>;
@@ -39,14 +37,14 @@ export default class BytecodeLoader implements Loader {
 
   async getTemplateIterator(app: Application, env: Environment, builder: ElementBuilder, scope: DynamicScope, self: PathReference<Opaque>): Promise<TemplateIterator> {
     let data = this.data;
-    let bytecode = await this.bytecode;
+    let buffer = await this.bytecode;
+    let { pool, heapTable, table, entryHandle: main, map, symbols, nextFreeHandle: handle } = data;
 
     let heap = new Heap({
-      ...data.heap,
-      buffer: bytecode
+      table: heapTable,
+      handle,
+      buffer
     });
-
-    let { pool, table, main, map, symbols } = data;
 
     let resolver = new BytecodeResolver(app, table, map, symbols);
     let constants = new RuntimeConstants(resolver, pool);

--- a/packages/@glimmer/application/src/loaders/bytecode/loader.ts
+++ b/packages/@glimmer/application/src/loaders/bytecode/loader.ts
@@ -22,7 +22,7 @@ export interface BytecodeData {
   table: Opaque[];
   map: Dict<number>;
   symbols: Dict<ProgramSymbolTable>;
-  mainSpecifier: string;
+  mainSpec: { specifier: string };
 }
 
 export interface BytecodeLoaderOptions {
@@ -49,7 +49,8 @@ export default class BytecodeLoader implements Loader {
   }
 
   loadMain(vm: LowLevelVM<Opaque>, self: RootReference<Opaque>) {
-    let { map, mainSpecifier, symbols, main } = this.data;
+    let { map, mainSpec, symbols, main } = this.data;
+    let mainSpecifier = mainSpec.specifier;
     let symbolTable = symbols[mainSpecifier];
     vm.pc = main;
     vm.pushFrame();

--- a/packages/@glimmer/application/src/loaders/bytecode/resolver.ts
+++ b/packages/@glimmer/application/src/loaders/bytecode/resolver.ts
@@ -18,22 +18,19 @@ function buildComponentDefinition(ComponentClass: Factory<Opaque>, manager: Comp
   };
 }
 
+export interface TemplateMeta {
+  locator: any;
+}
+
 export const enum ModuleTypes {
   HELPER_FACTORY,
   HELPER
 };
 
-export interface TemplateLocator {
-  module: string;
-  name: string;
-  meta: {
-    specifier: string;
-  };
-}
 /**
  * Exchanges VM handles for concrete implementations.
  */
-export default class BytecodeResolver implements RuntimeResolver<TemplateLocator> {
+export default class BytecodeResolver implements RuntimeResolver<TemplateMeta> {
   constructor(protected owner: Owner, protected table: Opaque[], protected map: Dict<number>, protected symbols: Dict<SymbolTable>) {
   }
 
@@ -46,11 +43,11 @@ export default class BytecodeResolver implements RuntimeResolver<TemplateLocator
    * The resolver is responsible for returning a component definition containing
    * the VM handle and symbol table for the resolved component.
    */
-  lookupComponent(name: string, referrer: TemplateLocator): ComponentDefinition {
+  lookupComponent(name: string, referrer: TemplateMeta): ComponentDefinition {
     let owner = this.owner;
     let manager = this.managerFor();
 
-    let templateSpecifier = owner.identify(`template:${name}`, referrer.meta.specifier);
+    let templateSpecifier = owner.identify(`template:${name}`, referrer.locator.specifier);
     let vmHandle = this.map[templateSpecifier];
     let symbolTable = this.symbols[templateSpecifier];
 
@@ -60,7 +57,7 @@ export default class BytecodeResolver implements RuntimeResolver<TemplateLocator
     return buildComponentDefinition(ComponentClass, manager, vmHandle, symbolTable);
   }
 
-  lookupPartial(name: string, referrer: TemplateLocator): number {
+  lookupPartial(name: string, referrer: TemplateMeta): number {
     throw unreachable();
   }
 

--- a/packages/@glimmer/application/src/templates/main-single-root.d.ts
+++ b/packages/@glimmer/application/src/templates/main-single-root.d.ts
@@ -1,0 +1,6 @@
+export default {
+  block: '',
+  meta: {
+    specifier: 'main'
+  }
+};

--- a/packages/@glimmer/application/src/templates/main-single-root.hbs
+++ b/packages/@glimmer/application/src/templates/main-single-root.hbs
@@ -1,0 +1,1 @@
+{{component @componentName.componentName model=@model.model}}

--- a/packages/@glimmer/application/test/browser/application-test.ts
+++ b/packages/@glimmer/application/test/browser/application-test.ts
@@ -72,7 +72,7 @@ test('can be instantiated with bytecode loader', function(assert) {
   let pool = new Program().constants.toPool();
   let bytecode = Promise.resolve(new ArrayBuffer(0));
   let data: BytecodeData = {
-    mainSpecifier: 'template:/app/components/main',
+    mainSpec: { specifier: 'mainTemplate' },
     heap: {
       table: [],
       handle: 0
@@ -97,13 +97,16 @@ test('can be instantiated with bytecode loader', function(assert) {
 test('can be booted with bytecode loader', async function(assert) {
   let delegate = new TestDelegate();
   let compiler = new BundleCompiler(delegate);
-  compiler.add({ name: 'default', module: 'main'}, '{{#each @roots key="id" as |root|}}{{/each}}');
+  let locator = {
+    name: 'mainTemplate', module: '@glimmer/application'
+  };
+  compiler.add(locator, '{{#each @roots key="id" as |root|}}{{/each}}');
   let result = compiler.compile();
 
   let resolver = new BlankResolver();
-  let symbolTable = result.symbolTables.get({ name: 'default', module: 'main' });
+  let symbolTable = result.symbolTables.get(locator);
   let data: BytecodeData = {
-    mainSpecifier: 'template:/app/components/main',
+    mainSpec: { specifier: 'mainTemplate' },
     heap: {
       table: result.heap.table,
       handle: result.heap.handle
@@ -112,10 +115,10 @@ test('can be booted with bytecode loader', async function(assert) {
     table: [],
     main: result.main,
     map: {
-      'template:/app/components/main': result.table.vmHandleByModuleLocator.get({ name: 'default', module: 'main'})
+      'mainTemplate': result.table.vmHandleByModuleLocator.get(locator)
     },
     symbols: {
-      'template:/app/components/main': symbolTable
+      'mainTemplate': symbolTable
     }
   };
 

--- a/packages/@glimmer/application/test/browser/application-test.ts
+++ b/packages/@glimmer/application/test/browser/application-test.ts
@@ -100,7 +100,7 @@ test('can be booted with bytecode loader', async function(assert) {
   let locator = {
     name: 'mainTemplate', module: '@glimmer/application'
   };
-  compiler.add(locator, '{{#each @roots key="id" as |root|}}{{/each}}');
+  compiler.add(locator, '{{component @componentName model=@model}}');
   let result = compiler.compile();
 
   let resolver = new BlankResolver();

--- a/packages/@glimmer/application/test/browser/application-test.ts
+++ b/packages/@glimmer/application/test/browser/application-test.ts
@@ -1,8 +1,57 @@
-import Application, { RuntimeCompilerLoader, SyncRenderer, DOMBuilder } from '@glimmer/application';
+import Application, { RuntimeCompilerLoader, SyncRenderer, DOMBuilder, BytecodeLoader, BytecodeData } from '@glimmer/application';
 import { BlankResolver } from '@glimmer/test-utils';
 import { Document } from 'simple-dom';
+import { Program } from '@glimmer/program';
+import { BundleCompiler, ModuleLocator, TemplateLocator, BundleCompilationResult } from '@glimmer/bundle-compiler';
+import { AppCompilerDelegate } from '@glimmer/compiler-delegates';
+import { ComponentCapabilities } from '@glimmer/interfaces';
+import { SerializedTemplateBlock } from '@glimmer/wire-format';
+import { CompileOptions } from '@glimmer/opcode-compiler';
 
 const { module, test } = QUnit;
+
+class TestDelegate implements AppCompilerDelegate<any> {
+  normalizePath(absolutePath: string): string {
+    throw new Error("Method not implemented.");
+  }
+  templateLocatorFor(moduleLocator: ModuleLocator): TemplateLocator<any> {
+    throw new Error("Method not implemented.");
+  }
+  generateDataSegment(compilation: BundleCompilationResult): string {
+    throw new Error("Method not implemented.");
+  }
+  hasComponentInScope(componentName: string, referrer: any): boolean {
+    throw new Error("Method not implemented.");
+  }
+  resolveComponent(componentName: string, referrer: any): ModuleLocator {
+    throw new Error("Method not implemented.");
+  }
+  getComponentCapabilities(locator: any): ComponentCapabilities {
+    throw new Error("Method not implemented.");
+  }
+  getComponentLayout(locator: any, block: SerializedTemplateBlock, options: CompileOptions<any>): never {
+    throw new Error("Method not implemented.");
+  }
+  hasHelperInScope(helperName: string, referrer: any): boolean {
+    throw new Error("Method not implemented.");
+  }
+  resolveHelper(helperName: string, referrer: any): ModuleLocator {
+    throw new Error("Method not implemented.");
+  }
+  hasModifierInScope(modifierName: string, referrer: any): boolean {
+    throw new Error("Method not implemented.");
+  }
+  resolveModifier(modifierName: string, referrer: any): ModuleLocator {
+    throw new Error("Method not implemented.");
+  }
+  hasPartialInScope(partialName: string, referrer: any): boolean {
+    throw new Error("Method not implemented.");
+  }
+  resolvePartial(partialName: string, referrer: any): ModuleLocator {
+    throw new Error("Method not implemented.");
+  }
+
+}
 
 module('[@glimmer/application] Application');
 
@@ -16,6 +65,71 @@ test('can be instantiated', function(assert) {
     resolver
   });
   assert.ok(app, 'app exists');
+});
+
+test('can be instantiated with bytecode loader', function(assert) {
+  let resolver = new BlankResolver();
+  let pool = new Program().constants.toPool();
+  let bytecode = Promise.resolve(new ArrayBuffer(0));
+  let data: BytecodeData = {
+    mainSpecifier: 'template:/app/components/main',
+    heap: {
+      table: [],
+      handle: 0
+    },
+    pool,
+    table: [],
+    main: 0,
+    map: {},
+    symbols: {}
+  };
+
+  let app = new Application({
+    rootName: 'app',
+    loader: new BytecodeLoader({ bytecode, data }),
+    renderer: new SyncRenderer(),
+    builder: new DOMBuilder({ element: document.body, nextSibling: null }),
+    resolver
+  });
+  assert.ok(app, 'app exists');
+});
+
+test('can be booted with bytecode loader', async function(assert) {
+  let delegate = new TestDelegate();
+  let compiler = new BundleCompiler(delegate);
+  compiler.add({ name: 'default', module: 'main'}, '{{#each @roots key="id" as |root|}}{{/each}}');
+  let result = compiler.compile();
+
+  let resolver = new BlankResolver();
+  let symbolTable = result.symbolTables.get({ name: 'default', module: 'main' });
+  let data: BytecodeData = {
+    mainSpecifier: 'template:/app/components/main',
+    heap: {
+      table: result.heap.table,
+      handle: result.heap.handle
+    },
+    pool: result.pool,
+    table: [],
+    main: result.main,
+    map: {
+      'template:/app/components/main': result.table.vmHandleByModuleLocator.get({ name: 'default', module: 'main'})
+    },
+    symbols: {
+      'template:/app/components/main': symbolTable
+    }
+  };
+
+  let app = new Application({
+    rootName: 'app',
+    loader: new BytecodeLoader({ bytecode: result.heap.buffer, data }),
+    renderer: new SyncRenderer(),
+    builder: new DOMBuilder({ element: document.body, nextSibling: null }),
+    resolver
+  });
+
+  await app.boot();
+
+  assert.ok(true, 'renders with no errors');
 });
 
 test('accepts options for rootName, resolver and document', function(assert) {

--- a/packages/@glimmer/application/test/browser/bytecode-loader-test.ts
+++ b/packages/@glimmer/application/test/browser/bytecode-loader-test.ts
@@ -1,0 +1,19 @@
+import { RenderTest, test, didRender, renderModule } from "@glimmer/application-test-helpers";
+
+class RenderComponentTest extends RenderTest {
+  @test async "renders a component with bytecode loader"(assert) {
+    assert.expect(1);
+    let app = await this.app
+      .template('HelloWorld', `<h1>Hello Glimmer!</h1>`)
+      .boot();
+
+    app.renderComponent({
+      component: 'HelloWorld'
+    });
+
+    await didRender(app);
+    this.assertHTML('<h1>Hello Glimmer!</h1>');
+  }
+}
+
+renderModule('[@glimmer/application] renderComponent', RenderComponentTest, { loader: 'bytecode' });

--- a/packages/@glimmer/application/test/browser/environment-test.ts
+++ b/packages/@glimmer/application/test/browser/environment-test.ts
@@ -113,9 +113,9 @@ test('custom elements are rendered', async function(assert) {
     .template('Main', '<hello-world>foo</hello-world>')
     .boot();
 
-  let serializedHTML = serializer.serialize(app.rootElement);
+  let serializedHTML = serializer.serializeChildren(app.rootElement);
 
-  assert.equal(serializedHTML, '<div><hello-world>foo</hello-world></div>');
+  assert.equal(serializedHTML, '<hello-world>foo</hello-world><!---->');
 });
 
 test('components without a template raise an error', async function(assert) {
@@ -192,13 +192,13 @@ test('renders a component using simple-dom', async function(assert) {
 
   let customDocument: Simple.Document = new SimpleDOM.Document();
 
-  let app = await buildApp({ document: customDocument })
+  let app = await buildApp({ document: customDocument, renderMode: 'server' })
     .template('Main', `<h1>Hello Glimmer!</h1>`)
     .boot();
 
   let serializedHTML = serializer.serialize(app.rootElement);
 
-  assert.equal(serializedHTML, '<div><h1>Hello Glimmer!</h1></div>');
+  assert.equal(serializedHTML, '<div><h1>Hello Glimmer!</h1><!----></div>');
 });
 
 if (DEBUG) {

--- a/packages/@glimmer/application/test/browser/helpers/async.ts
+++ b/packages/@glimmer/application/test/browser/helpers/async.ts
@@ -1,0 +1,34 @@
+declare interface Assert {
+  rejects(promise: Promise<any>, expected?: any, message?: any): Promise<void>;
+}
+
+Object.assign(QUnit.assert.constructor.prototype, {
+  async rejects(promise: Promise<any>, expected?: any, message?: string) {
+    let actual = undefined;
+    let result = false;
+
+    try {
+      await promise;
+    } catch (err) {
+      actual = err;
+    }
+
+    if (actual) {
+      if (!expected) {
+        result = true;
+        expected = null;
+      } else if (expected instanceof RegExp) {
+        result = expected.test(actual.toString());
+      } else if (typeof expected === 'function' && actual instanceof expected) {
+        result = true;
+      }
+    }
+
+    QUnit.config.current.pushResult({
+      result,
+      actual,
+      expected,
+      message
+    });
+  }
+});

--- a/packages/@glimmer/application/test/browser/render-component-test.ts
+++ b/packages/@glimmer/application/test/browser/render-component-test.ts
@@ -1,25 +1,8 @@
-import { didRender } from '@glimmer/application-test-helpers';
-import './helpers/async';
-import { test, RenderTest, renderModule } from '@glimmer/application-test-helpers';
+import { buildApp, didRender } from '@glimmer/application-test-helpers';
+import { DEBUG } from '@glimmer/env';
 
-// const { module, test } = QUnit;
+const { module, test } = QUnit;
 
-class RenderComponentTest extends RenderTest {
-  @test async "renders a component"(assert) {
-    assert.expect(1);
-    let app = await this.app
-      .template('HelloWorld', `<h1>Hello Glimmer!</h1>`)
-      .template('Main', '<HelloWorld />')
-      .boot();
-
-    await didRender(app);
-    assert.equal('<h1>Hello Glimmer!</h1>', document.getElementById('qunit-fixture').innerHTML);
-  }
-}
-
-renderModule('[@glimmer/application] renderComponent', RenderComponentTest);
-
-/*
 module('[@glimmer/application] renderComponent');
 
 test('renders a component', async function(assert) {
@@ -174,4 +157,3 @@ async function rejects(assert: Assert, promise: Promise<any>, message: RegExp) {
     });
   }
 }
-*/

--- a/packages/@glimmer/application/test/browser/render-component-test.ts
+++ b/packages/@glimmer/application/test/browser/render-component-test.ts
@@ -7,17 +7,13 @@ import { test, RenderTest, renderModule } from '@glimmer/application-test-helper
 class RenderComponentTest extends RenderTest {
   @test async "renders a component"(assert) {
     assert.expect(1);
-    let containerElement = document.createElement('div');
     let app = await this.app
       .template('HelloWorld', `<h1>Hello Glimmer!</h1>`)
       .template('Main', '<HelloWorld />')
       .boot();
 
-    // app.renderComponent('HelloWorld', containerElement);
-
     await didRender(app);
-
-    assert.equal(containerElement.innerHTML, '<h1>Hello Glimmer!</h1>');
+    assert.equal('<h1>Hello Glimmer!</h1>', document.getElementById('qunit-fixture').innerHTML);
   }
 }
 

--- a/packages/@glimmer/application/test/browser/render-component-test.ts
+++ b/packages/@glimmer/application/test/browser/render-component-test.ts
@@ -1,8 +1,29 @@
-import { buildApp, didRender } from '@glimmer/application-test-helpers';
-import { DEBUG } from '@glimmer/env';
+import { didRender } from '@glimmer/application-test-helpers';
+import './helpers/async';
+import { test, RenderTest, renderModule } from '@glimmer/application-test-helpers';
 
-const { module, test } = QUnit;
+// const { module, test } = QUnit;
 
+class RenderComponentTest extends RenderTest {
+  @test async "renders a component"(assert) {
+    assert.expect(1);
+    let containerElement = document.createElement('div');
+    let app = await this.app
+      .template('HelloWorld', `<h1>Hello Glimmer!</h1>`)
+      .template('Main', '<HelloWorld />')
+      .boot();
+
+    // app.renderComponent('HelloWorld', containerElement);
+
+    await didRender(app);
+
+    assert.equal(containerElement.innerHTML, '<h1>Hello Glimmer!</h1>');
+  }
+}
+
+renderModule('[@glimmer/application] renderComponent', RenderComponentTest);
+
+/*
 module('[@glimmer/application] renderComponent');
 
 test('renders a component', async function(assert) {
@@ -157,3 +178,4 @@ async function rejects(assert: Assert, promise: Promise<any>, message: RegExp) {
     });
   }
 }
+*/

--- a/packages/@glimmer/compiler-delegates/src/module-unification/code-generator.ts
+++ b/packages/@glimmer/compiler-delegates/src/module-unification/code-generator.ts
@@ -51,7 +51,7 @@ export default class MUCodeGenerator {
       ${specifierMap}
       ${symbolTables}
       const entryHandle = ${main.toString()};
-      export default { table, heap, pool, map, symbols, entryHandle };`;
+      export default { table, heap, pool, map, symbols, entryHandle, nextFreeHandle };`;
     debug("generated data segment; source=%s", source);
 
     return source;
@@ -89,7 +89,8 @@ export default class MUCodeGenerator {
   generateHeap(heap: SerializedHeap) {
     assert((heap.table.length / 2) % 1 === 0, 'Heap table should be balanced and divisible by 2');
     return strip`
-      const heap = ${inlineJSON(heap.table)};
+      const nextFreeHandle = ${heap.handle.toString()};
+      const heapTable = ${inlineJSON(heap.table)};
     `;
   }
 

--- a/packages/@glimmer/compiler-delegates/src/module-unification/code-generator.ts
+++ b/packages/@glimmer/compiler-delegates/src/module-unification/code-generator.ts
@@ -50,8 +50,8 @@ export default class MUCodeGenerator {
       ${constantPool}
       ${specifierMap}
       ${symbolTables}
-      const entryHandle = ${main.toString()};
-      export default { table, heap, pool, map, symbols, entryHandle, nextFreeHandle };`;
+      const main = ${main.toString()};
+      export default { table, heap, pool, map, symbols, main };`;
     debug("generated data segment; source=%s", source);
 
     return source;
@@ -88,9 +88,9 @@ export default class MUCodeGenerator {
 
   generateHeap(heap: SerializedHeap) {
     assert((heap.table.length / 2) % 1 === 0, 'Heap table should be balanced and divisible by 2');
+    let serializedHeap = { table: heap.table, handle: heap.handle };
     return strip`
-      const nextFreeHandle = ${heap.handle.toString()};
-      const heapTable = ${inlineJSON(heap.table)};
+      const heap = ${inlineJSON(serializedHeap)};
     `;
   }
 

--- a/packages/@glimmer/compiler-delegates/src/module-unification/compiler-delegate.ts
+++ b/packages/@glimmer/compiler-delegates/src/module-unification/compiler-delegate.ts
@@ -39,8 +39,12 @@ export default class MUCompilerDelegate implements AppCompilerDelegate<TemplateM
   }
 
   protected _builtins() {
+    let mainLocator = this.templateLocatorFor({
+      module: '@glimmer/application',
+      name: 'mainTemplate'
+    });
     return {
-      main: helperLocatorFor('main', 'mainTemplate'),
+      main: mainLocator,
       if: helperLocatorFor('@glimmer/application', 'ifHelper'),
       action: helperLocatorFor('@glimmer/application', 'actionHelper')
     };
@@ -62,9 +66,15 @@ export default class MUCompilerDelegate implements AppCompilerDelegate<TemplateM
    */
   templateLocatorFor({ module, name }: ModuleLocator): TemplateLocator<TemplateMeta> {
     let relativePath = module.replace(/^\.\//, '');
-    let meta = {
-      specifier: this.project.specifierForPath(relativePath)
-    };
+
+    let meta;
+    if (name === 'mainTemplate') {
+      meta = { specifier: name };
+    } else {
+      meta = {
+        specifier: this.project.specifierForPath(relativePath)
+      };
+    }
 
     return { kind: 'template', module, name, meta };
   }

--- a/packages/@glimmer/compiler-delegates/test/node/module-unification-test.ts
+++ b/packages/@glimmer/compiler-delegates/test/node/module-unification-test.ts
@@ -54,9 +54,9 @@ test('can generate the serialized constants pool ', (assert) => {
 });
 
 test('can generate the heap table', (assert) => {
-  let serializedHeaptable = generator.generateHeap({ table: [0, 650, 40, 700] } as any);
+  let serializedHeaptable = generator.generateHeap({ table: [0, 650, 40, 700], handle: 50 } as any);
 
-  assert.equal(serializedHeaptable, `const heap =JSON.parse(${JSON.stringify(JSON.stringify([0, 650, 40, 700]))});`);
+  assert.equal(serializedHeaptable, `const nextFreeHandle =50;const heapTable =JSON.parse(${JSON.stringify(JSON.stringify([0, 650, 40, 700]))});`);
 });
 
 test('heap table should be balanced', (assert) => {

--- a/packages/@glimmer/compiler-delegates/test/node/module-unification-test.ts
+++ b/packages/@glimmer/compiler-delegates/test/node/module-unification-test.ts
@@ -54,9 +54,10 @@ test('can generate the serialized constants pool ', (assert) => {
 });
 
 test('can generate the heap table', (assert) => {
-  let serializedHeaptable = generator.generateHeap({ table: [0, 650, 40, 700], handle: 50 } as any);
+  let heap = { table: [0, 650, 40, 700], handle: 50, buffer: new ArrayBuffer(1) };
+  let serializedHeaptable = generator.generateHeap(heap as any);
 
-  assert.equal(serializedHeaptable, `const nextFreeHandle =50;const heapTable =JSON.parse(${JSON.stringify(JSON.stringify([0, 650, 40, 700]))});`);
+  assert.equal(serializedHeaptable, `const heap =JSON.parse(${JSON.stringify(JSON.stringify({ table: [0, 650, 40, 700], handle: 50 }))});`);
 });
 
 test('heap table should be balanced', (assert) => {


### PR DESCRIPTION
This introduces the plumbing for the virtual invocation of the `mainTemplate` for a Glimmer Application running with the bytecode format.

# What This PR Does
In lazy mode we have the luxury of having a concrete precompiled `mainTemplate` in javascript that we can invoke by calling `renderLayout` with a preloaded context known as `self`. This would in return bind the seed data and render the UI. In the bytecode mode we do not have a concrete function to invoke, as the template is now just a binary blob. So to begin the execution we need a virtualized way of invoking the `mainTemplate`. To account for this the VM now has a `main` opcode that is responsible for invoking the binary version of the `mainTemplate`. That being said the host needs to do a bit of prep-work before the VM starts executing.

Prior to executing, the environment needs to load the stack with all the pieces of data that are required for a component invocation. This means we need to load an `Invocation`, `ComponentDefinition`, and `ARGS` on the stack in preparation for the invocation of the `mainTemplate`. This forces a lookup convention for data associated with the `mainTemplate`.

A template that is added to the Bundle Compiler with the locator of the following will be used as the `mainTemplate`.

```
{ module: '@glimmer/application', name: 'mainTemplate' }
```

