### PR TITLE
BUGFIX: Builtin helpers and app helpers serialization

### DIFF
--- a/packages/@glimmer/compiler-delegates/src/module-unification/code-generator.ts
+++ b/packages/@glimmer/compiler-delegates/src/module-unification/code-generator.ts
@@ -182,7 +182,7 @@ export default class MUCodeGenerator {
         relativePath
       );
 
-      return { module: relativePath, name };
+      return {...locator, module: relativePath, name };
     }
   }
 }

--- a/packages/@glimmer/compiler-delegates/src/module-unification/compiler-delegate.ts
+++ b/packages/@glimmer/compiler-delegates/src/module-unification/compiler-delegate.ts
@@ -50,8 +50,8 @@ export default class MUCompilerDelegate implements AppCompilerDelegate<TemplateM
     });
     return {
       mainTemplate,
-      if: helperLocatorFor('@glimmer/application', 'ifHelper', false),
-      action: helperLocatorFor('@glimmer/application', 'actionHelper')
+      if: helperLocatorFor('@glimmer/application', 'ifHelper'),
+      action: helperLocatorFor('@glimmer/application', 'actionHelper', true)
     };
   }
 
@@ -114,7 +114,8 @@ export default class MUCompilerDelegate implements AppCompilerDelegate<TemplateM
     if (helperName in this.builtins) { return this.builtins[helperName]; }
 
     let specifier = this.project.resolver.identify(`helper:${helperName}`, referrer.specifier);
-    return this.moduleLocatorFor(specifier);
+    let module = `./${this.project.pathForSpecifier(specifier)}`;
+    return helperLocatorFor(module, 'default');
   }
 
   getComponentLayout(_meta: TemplateMeta, block: SerializedTemplateBlock, options: CompileOptions<TemplateMeta>): ICompilableTemplate<ProgramSymbolTable> {
@@ -143,7 +144,7 @@ export default class MUCompilerDelegate implements AppCompilerDelegate<TemplateM
   }
 }
 
-function helperLocatorFor(module: string, name: string, factory = true): HelperLocator {
+function helperLocatorFor(module: string, name: string, factory = false): HelperLocator {
   return {
     kind: 'helper',
     module,

--- a/packages/@glimmer/compiler-delegates/test/node/application-smoke-test.ts
+++ b/packages/@glimmer/compiler-delegates/test/node/application-smoke-test.ts
@@ -1,6 +1,6 @@
 import Application, { BytecodeLoader, SyncRenderer } from '@glimmer/application';
 import { StringBuilder } from '@glimmer/ssr';
-import { module, test} from 'qunitjs';
+import { module, test } from 'qunitjs';
 import * as SimpleDOM from 'simple-dom';
 import Resolver, { BasicModuleRegistry } from '@glimmer/resolver';
 import { ComponentManager } from '@glimmer/component';
@@ -55,5 +55,5 @@ test('Boots and renders an app', async function(assert) {
 
   await app.boot();
 
-  assert.equal(serializer.serializeChildren(doc.body as any).trim(), '<div class="user">Chad STUB</div>');
+  assert.equal(serializer.serializeChildren(doc.body as any).trim(), '<div class="user">Chad IF_STUB ID_STUB WAT_STUB</div>');
 });

--- a/packages/@glimmer/compiler-delegates/test/node/fixtures/mu/src/ui/components/User/template.hbs
+++ b/packages/@glimmer/compiler-delegates/test/node/fixtures/mu/src/ui/components/User/template.hbs
@@ -1,1 +1,1 @@
-<div class="user">{{@name}} {{if @name "done"}}</div>
+<div class="user">{{@name}} {{if @name "done"}} {{id "plz"}} {{wat "no more"}}</div>

--- a/packages/@glimmer/compiler-delegates/test/node/fixtures/mu/src/ui/components/id/helper.ts
+++ b/packages/@glimmer/compiler-delegates/test/node/fixtures/mu/src/ui/components/id/helper.ts
@@ -1,0 +1,3 @@
+export default function id(param) {
+  return param[0];
+}

--- a/packages/@glimmer/compiler-delegates/test/node/helpers/build-server.ts
+++ b/packages/@glimmer/compiler-delegates/test/node/helpers/build-server.ts
@@ -22,6 +22,9 @@ export class BuildServer {
     this.projectPath = findup(relativeProjectPath);
     this.delegate = new MUCompilerDelegate({
       projectPath: this.projectPath,
+      builtins: {
+        'wat': { kind: 'helper', module: '@css-blocks', name: 'wat', meta: { factory: false } },
+      },
       mainTemplateLocator: customLocator,
       outputFiles: {
         dataSegment: 'data.js',
@@ -50,7 +53,9 @@ export class BuildServer {
       entry: path.join(tmp, 'smoke-data.js'),
       plugins: [
         virtual({
-          '@glimmer/application': 'export const ifHelper = () => { return "STUB" };'
+          './src/ui/components/id/helper': 'export default function id() { return "ID_STUB"; }',
+          '@css-blocks': 'export const wat = () => { return "WAT_STUB"; }',
+          '@glimmer/application': 'export const ifHelper = () => { return "IF_STUB" };'
         })
       ]
     });


### PR DESCRIPTION
This fixes the serialization issues related to helpers when running with the bundle compiler. Today there are several types of helpers:

1. Host specific (action, if)
2. App Helpers
3. 3rd Party

When we are serializing the data segment we construct the external module table. The external module table is where the VM trades out an opaque handle for a live JavaScript object. For component classes this works great as they do not need to be wrapped in a reference. Helpers on the other hand do need to be wrapped in a reference prior to evaluation. Further more helpers like `{{action}}` are implemented in a way that produces references where as user space helpers are just functions that get wrapped in references. Since there currently isn't a unification here we need to differentiate in the serialized output if we need to wrap the helper in the a reference. This fixes am issue where this wrapping information was being lost during serialization.

