### PR TITLE
TravisCI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 dist: trusty
 
 language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,14 @@ language: node_js
 node_js:
   - "8"
 
+env:
+  - MOZ_HEADLESS=1
+
 cache: yarn
 
 addons:
   chrome: stable
-  firefox: "54.0"
+  firefox: latest
 
 before_install:
   - "curl -o- -L https://yarnpkg.com/install.sh | bash -s --"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
-language: node_js
 sudo: required
 dist: trusty
+
+language: node_js
+node_js:
+  - "8"
+
 cache: yarn
 
 addons:
@@ -13,5 +17,3 @@ before_install:
   - "curl -o- -L https://yarnpkg.com/install.sh | bash -s --"
   - export PATH="$HOME/.yarn/bin:$PATH"
 
-node_js:
-  - "8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,10 @@ node_js:
 cache: yarn
 
 addons:
+  chrome: stable
   firefox: "54.0"
 
 before_install:
-  - "export CHROME_BIN=chromium-browser"
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
   - "curl -o- -L https://yarnpkg.com/install.sh | bash -s --"
   - export PATH="$HOME/.yarn/bin:$PATH"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,8 @@ before_install:
   - "curl -o- -L https://yarnpkg.com/install.sh | bash -s --"
   - export PATH="$HOME/.yarn/bin:$PATH"
 
+install:
+  - yarn install --non-interactive
+
+script:
+  - yarn test


### PR DESCRIPTION
This PR changes the TravisCI config to:

- use headless Chrome
- use headless Firefox
- use the faster container-based infrastructure (`sudo: false` since `xvfb` is not needed anymore)
