### PR TITLE
Update broccoli dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "broccoli-babel-transpiler": "^6.1.2",
     "broccoli-concat": "^3.2.2",
     "broccoli-file-creator": "^1.1.1",
-    "broccoli-funnel": "^1.1.0",
+    "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-persistent-filter": "^1.2.13",
     "broccoli-rollup": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "broccoli-concat": "^3.2.2",
     "broccoli-file-creator": "^1.1.1",
     "broccoli-funnel": "^1.1.0",
-    "broccoli-merge-trees": "^1.1.1",
+    "broccoli-merge-trees": "^2.0.0",
     "broccoli-persistent-filter": "^1.2.13",
     "broccoli-rollup": "^1.3.0",
     "broccoli-tslinter": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1584,7 +1584,7 @@ broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^2.0.0:
+broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz#6823c73b675ef78fffa7ab800f083e768b51d449"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3675,9 +3675,18 @@ fs-readdir-recursive@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz#315b4fb8c1ca5b8c47defef319d073dad3568059"
 
-fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6:
+fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.6.tgz#342665749e8dca406800b672268c8f5073f3e623"
+  dependencies:
+    heimdalljs-logger "^0.1.7"
+    object-assign "^4.1.0"
+    path-posix "^1.0.0"
+    symlink-or-copy "^1.1.8"
+
+fs-tree-diff@^0.5.4:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz#315e2b098d5fe7f622880ac965b1b051868ac871"
   dependencies:
     heimdalljs-logger "^0.1.7"
     object-assign "^4.1.0"


### PR DESCRIPTION
The main change in these new major versions was removing Node 0.12 compatibility.