### PR TITLE
Refactor Data Segment

### DIFF
--- a/packages/@glimmer/app-compiler/test/node/bundle-compiler-test.ts
+++ b/packages/@glimmer/app-compiler/test/node/bundle-compiler-test.ts
@@ -174,9 +174,8 @@ module('Broccol Glimmer Bundle Compiler', function(hooks) {
     assert.ok(dataSegment.length > 0, 'data segment is populated');
     assert.ok(dataSegment.indexOf('table') > -1, 'has a table');
     assert.ok(dataSegment.indexOf('heap') > -1, 'has a heap');
-    assert.ok(dataSegment.indexOf('symbols') > -1, 'has symbol tables');
     assert.ok(dataSegment.indexOf('pool') > -1, 'has a constant pool');
-    assert.ok(dataSegment.indexOf('map') > -1, 'has a specifier map');
+    assert.ok(dataSegment.indexOf('meta') > -1, 'has a specifier map');
   });
 
   test('can lookup builtins', async function(assert) {

--- a/packages/@glimmer/application/src/loaders/bytecode/loader.ts
+++ b/packages/@glimmer/application/src/loaders/bytecode/loader.ts
@@ -14,13 +14,18 @@ export interface SerializedHeap {
   handle: number;
 }
 
+export interface Metadata {
+  h: number;
+  table: ProgramSymbolTable;
+}
+
 export interface BytecodeData {
+  prefix: string;
   mainEntry: number;
   heap: SerializedHeap;
   pool: ConstantPool;
+  meta: Dict<Metadata>;
   table: Opaque[];
-  map: Dict<number>;
-  symbols: Dict<ProgramSymbolTable>;
 }
 
 export interface BytecodeLoaderOptions {
@@ -40,7 +45,7 @@ export default class BytecodeLoader implements Loader {
   async getTemplateIterator(app: Application, env: Environment, builder: ElementBuilder, scope: DynamicScope, self: PathReference<Opaque>): Promise<TemplateIterator> {
     let data = this.data;
     let bytecode = await this.bytecode;
-    let { pool, heap: serializedHeap, table, map, symbols, mainEntry } = data;
+    let { pool, heap: serializedHeap, table, meta, prefix, mainEntry } = data;
 
     let heap = new Heap({
       table: serializedHeap.table,
@@ -48,7 +53,7 @@ export default class BytecodeLoader implements Loader {
       buffer: bytecode
     });
 
-    let resolver = new BytecodeResolver(app, table, map, symbols);
+    let resolver = new BytecodeResolver(app, table, meta, prefix);
     let constants = new RuntimeConstants(resolver, pool);
     let program = new RuntimeProgram(constants, heap);
 

--- a/packages/@glimmer/application/test/browser/application-test.ts
+++ b/packages/@glimmer/application/test/browser/application-test.ts
@@ -73,6 +73,7 @@ test('can be instantiated with bytecode loader', function(assert) {
   let pool = new Program().constants.toPool();
   let bytecode = Promise.resolve(new ArrayBuffer(0));
   let data: BytecodeData = {
+    prefix: '',
     heap: {
       table: [],
       handle: 0
@@ -80,8 +81,7 @@ test('can be instantiated with bytecode loader', function(assert) {
     pool,
     table: [],
     mainEntry: 0,
-    map: {},
-    symbols: {}
+    meta: {}
   };
 
   let app = new Application({
@@ -113,6 +113,7 @@ test('can be booted with bytecode loader', async function(assert) {
   let resolver = new BlankResolver();
   let symbolTable = result.symbolTables.get(locator);
   let data: BytecodeData = {
+    prefix: '',
     heap: {
       table: result.heap.table,
       handle: result.heap.handle
@@ -120,11 +121,11 @@ test('can be booted with bytecode loader', async function(assert) {
     pool: result.pool,
     table: [],
     mainEntry: result.table.vmHandleByModuleLocator.get(locator),
-    map: {
-      'mainTemplate': result.table.vmHandleByModuleLocator.get(locator)
-    },
-    symbols: {
-      'mainTemplate': symbolTable
+    meta: {
+      'mainTemplate': {
+        h: result.table.vmHandleByModuleLocator.get(locator),
+        table: symbolTable
+      }
     }
   };
 

--- a/packages/@glimmer/compiler-delegates/test/node/module-unification-test.ts
+++ b/packages/@glimmer/compiler-delegates/test/node/module-unification-test.ts
@@ -71,22 +71,22 @@ test('can generate the specifier map', (assert) => {
   table.vmHandleByModuleLocator.set({name: 'default', module: './src/ui/components/x/template.hbs' }, 0);
   let serializedTable = generator.generateSpecifierMap(table);
 
-  assert.equal(serializedTable, `const map = JSON.parse(${JSON.stringify(JSON.stringify({'template:/my-project/components/x': 0}))});`);
+  assert.deepEqual(serializedTable, {'template:/my-project/components/x': 0});
 });
 
 test('specifier\'s module path needs to be well formed', (assert) => {
   table.vmHandleByModuleLocator.set({name: 'default', module: 'B' }, 0);
 
-  assert.equal(generator.generateSpecifierMap(table), 'const map = JSON.parse("{}");', 'does not generate specifier map entry for non-MU modules');
+  assert.deepEqual(generator.generateSpecifierMap(table), {}, 'does not generate specifier map entry for non-MU modules');
 });
 
 test('can generate symbol tables', (assert) => {
   symbolTables.set({name: 'default', module: './src/ui/components/x/template.hbs' }, {
-    hasEval: false,
+    hasEval: 0,
     symbols: []
   } as any);
   let serializedSymbolTables = generator.generateSymbolTables(symbolTables);
-  assert.equal(serializedSymbolTables, `const symbols = JSON.parse(${JSON.stringify(JSON.stringify({"template:/my-project/components/x": {hasEval: false, symbols: []} }))});`);
+  assert.deepEqual(serializedSymbolTables, {"template:/my-project/components/x": {hasEval: 0, symbols: [] }});
 });
 
 test('can generate the external module table', (assert) => {


### PR DESCRIPTION
This reduces the overall size of the data segment by doing 2 things:

1) Interning the common prefix of the specifier
2) Collapsing the symbol table and handle map under the same key

To do the interning of the MU specifier we simply collect up all of the specifiers we need to serialize off and then find the common prefix amongst them and make it available to the resolver for resolution.

Prior to these changes the symbol tables and the handle map had the same key (MU specifier). This collapses these 2 concerns into 1 object.

The end result ends up looking something like the following:

```js
const prefix = 'template:/my-project/components/';
const meta = {
  "X": { h: 1, table: { hasEval: 0, symbols: ['@foo'] },
  "Y": { h: 2, table: { hasEval: 0, symbols: ['@bar'] },
...
}

```