### PR TITLE
Implicit 'projectPath' for Broccoli Plugin

### DIFF
--- a/packages/@glimmer/app-compiler/src/bundle-compiler.ts
+++ b/packages/@glimmer/app-compiler/src/bundle-compiler.ts
@@ -41,8 +41,8 @@ export default class GlimmerBundleCompiler extends Plugin {
 
     return Object.assign({
       outputFiles: {
-        heapFile: 'src/templates.gbx',
-        dataSegment: 'src/data-segment.js'
+        heapFile: 'templates.gbx',
+        dataSegment: 'data-segment.js'
       }
     }, options);
   }
@@ -83,6 +83,8 @@ export default class GlimmerBundleCompiler extends Plugin {
 
     this.compiler.addCompilableTemplate(locator, compilable);
 
+    let [projectPath] = this.inputPaths;
+
     this.listEntries().forEach(entry => {
       let { relativePath } = entry;
       if (entry.isDirectory()) {
@@ -90,7 +92,7 @@ export default class GlimmerBundleCompiler extends Plugin {
       } else {
         let content = this._readFile(relativePath);
         if (extname(relativePath) === '.hbs') {
-          let normalizedPath = this.delegate.normalizePath(relativePath);
+          let normalizedPath = this.delegate.normalizePath(join(projectPath, relativePath));
           let moduleLocator = { module: normalizedPath, name: 'default' };
           let templateLocator = this.delegate.templateLocatorFor(moduleLocator);
           this.compiler.add(templateLocator, content);

--- a/packages/@glimmer/app-compiler/src/bundle-compiler.ts
+++ b/packages/@glimmer/app-compiler/src/bundle-compiler.ts
@@ -16,8 +16,7 @@ export interface AppCompilerDelegateConstructor {
 }
 
 export interface GlimmerBundleCompilerOptions {
-  projectPath: string;
-  bundleCompiler: BundleCompilerOptions;
+  bundleCompiler?: BundleCompilerOptions;
   outputFiles?: OutputFiles;
   delegate?: AppCompilerDelegateConstructor;
   mode?: CompilerMode;
@@ -30,16 +29,12 @@ export default class GlimmerBundleCompiler extends Plugin {
   outputPath: string;
   compiler: BundleCompiler<Opaque>;
   private delegate: AppCompilerDelegate<Opaque>;
-  constructor(inputNode, options) {
+  constructor(inputNode, options: GlimmerBundleCompilerOptions) {
     super([inputNode], options);
     this.options = this.defaultOptions(options);
   }
 
   private defaultOptions(options: GlimmerBundleCompilerOptions) {
-    if (!options.projectPath) {
-      throw new Error('Must supply a projectPath');
-    }
-
     if (!options.mode && !options.delegate) {
       throw new Error('Must pass a bundle compiler mode or pass a custom compiler delegate.');
     }
@@ -64,7 +59,8 @@ export default class GlimmerBundleCompiler extends Plugin {
   createBundleCompiler() {
     let delegate;
     let options = this.options;
-    let { projectPath, outputFiles, builtins } = options;
+    let { outputFiles, builtins } = options;
+    let [projectPath] = this.inputPaths;
 
     if (options.mode && options.mode === 'module-unification') {
       delegate = this.delegate = new MUCompilerDelegate({ projectPath, outputFiles, builtins });

--- a/packages/@glimmer/app-compiler/test/node/bundle-compiler-test.ts
+++ b/packages/@glimmer/app-compiler/test/node/bundle-compiler-test.ts
@@ -5,7 +5,7 @@ import { MUCompilerDelegate } from '@glimmer/compiler-delegates';
 
 class TestModuleUnificationDelegate extends MUCompilerDelegate {
   normalizePath(modulePath: string): string {
-    return modulePath.replace('my-app/', './');
+    return `./${modulePath}`;
   }
 }
 
@@ -20,44 +20,34 @@ module('Broccol Glimmer Bundle Compiler', function(hooks) {
 
   test('requires a mode or delegate', function (assert) {
     assert.throws(() => {
-      new GlimmerBundleCompiler(input.path(), { projectPath: 'src' });
+      new GlimmerBundleCompiler(input.path(), {});
     }, /Must pass a bundle compiler mode or pass a custom compiler delegate\./);
-  });
-
-  test('requires a project path', function (assert) {
-    assert.throws(() => {
-      new GlimmerBundleCompiler(input.path(), {
-        mode: 'module-unification'
-      });
-    }, /Must supply a projectPath/);
   });
 
   test('syncs forward all files', async function(assert) {
     input.write({
-      'my-app': {
-        'package.json': JSON.stringify({name: 'my-app'}),
-        src: {
-          ui: {
-            components: {
-              A: {
-                'template.hbs': '<div>Hello</div>',
-                'component.ts': 'export default class A {}'
-              },
+      'package.json': JSON.stringify({name: 'my-app'}),
+      src: {
+        ui: {
+          components: {
+            A: {
+              'template.hbs': '<div>Hello</div>',
+              'component.ts': 'export default class A {}'
+            },
 
-              B: {
-                'template.hbs': 'From B: <A @foo={{bar}} /> {{@bar}}',
-                'component.ts': 'export default class B {}'
-              },
+            B: {
+              'template.hbs': 'From B: <A @foo={{bar}} /> {{@bar}}',
+              'component.ts': 'export default class B {}'
+            },
 
-              C: {
-                'template.hbs': 'From C',
-                'component.ts': 'export default class C {}'
-              },
+            C: {
+              'template.hbs': 'From C',
+              'component.ts': 'export default class C {}'
+            },
 
-              D: {
-                'template.hbs': '{{component C}}',
-                'component.ts': 'export default class D {}'
-              }
+            D: {
+              'template.hbs': '{{component C}}',
+              'component.ts': 'export default class D {}'
             }
           }
         }
@@ -65,49 +55,45 @@ module('Broccol Glimmer Bundle Compiler', function(hooks) {
     });
 
     let compiler = new GlimmerBundleCompiler(input.path(), {
-      projectPath: `${input.path()}/my-app`,
       delegate: TestModuleUnificationDelegate,
       outputFiles: {
-        dataSegment: 'my-app/data.js',
-        heapFile: 'my-app/templates.gbx'
+        dataSegment: 'data.js',
+        heapFile: 'templates.gbx'
       }
     });
 
     let output = await buildOutput(compiler);
     let files = output.read();
 
-    assert.deepEqual(Object.keys(files), ['my-app']);
-    assert.deepEqual(Object.keys(files['my-app']).sort(), ['src', 'package.json', 'templates.gbx', 'data.js'].sort());
-    assert.deepEqual(Object.keys(files['my-app']['src']).sort(), ['ui'].sort());
-    assert.deepEqual(Object.keys(files['my-app']['src'].ui), ['components']);
+    assert.deepEqual(Object.keys(files).sort(), ['src', 'package.json', 'templates.gbx', 'data.js'].sort());
+    assert.deepEqual(Object.keys(files['src']).sort(), ['ui'].sort());
+    assert.deepEqual(Object.keys(files['src']['ui']), ['components']);
 
-    Object.keys(files['my-app']['src'].ui.components).forEach((component) => {
-      assert.deepEqual(Object.keys(files['my-app']['src'].ui.components[component]), ['component.ts']);
+    Object.keys(files['src']['ui'].components).forEach((component) => {
+      assert.deepEqual(Object.keys(files['src']['ui'].components[component]), ['component.ts']);
     });
   });
 
   test('[MU] compiles the gbx and data segment', async function(assert) {
     input.write({
-      'my-app': {
-        'package.json': JSON.stringify({name: 'my-app'}),
-        src: {
-          ui: {
-            components: {
-              A: {
-                'template.hbs': '<div>Hello</div>'
-              },
+      'package.json': JSON.stringify({name: 'my-app'}),
+      src: {
+        ui: {
+          components: {
+            A: {
+              'template.hbs': '<div>Hello</div>'
+            },
 
-              B: {
-                'template.hbs': 'From B: <A @foo={{bar}} /> {{@bar}}'
-              },
+            B: {
+              'template.hbs': 'From B: <A @foo={{bar}} /> {{@bar}}'
+            },
 
-              C: {
-                'template.hbs': 'From C'
-              },
+            C: {
+              'template.hbs': 'From C'
+            },
 
-              D: {
-                'template.hbs': '{{component C}}'
-              }
+            D: {
+              'template.hbs': '{{component C}}'
             }
           }
         }
@@ -115,44 +101,41 @@ module('Broccol Glimmer Bundle Compiler', function(hooks) {
     });
 
     let compiler = new GlimmerBundleCompiler(input.path(), {
-      projectPath: `${input.path()}/my-app`,
       delegate: TestModuleUnificationDelegate,
       outputFiles: {
-        dataSegment: 'my-app/src/data.js',
-        heapFile: 'my-app/src/templates.gbx'
+        dataSegment: 'src/data.js',
+        heapFile: 'src/templates.gbx'
       }
     });
 
     let output = await buildOutput(compiler);
     let files = output.read();
 
-    let buffer = new Uint16Array(files['my-app']['src']['templates.gbx']);
+    let buffer = new Uint16Array(files['src']['templates.gbx']);
 
     assert.ok(buffer, 'Buffer is aligned');
   });
 
   test('data segment has all segments', async function(assert) {
     input.write({
-      'my-app': {
-        'package.json': JSON.stringify({name: 'my-app'}),
-        src: {
-          ui: {
-            components: {
-              A: {
-                'template.hbs': '<div>Hello</div>'
-              },
+      'package.json': JSON.stringify({name: 'my-app'}),
+      src: {
+        ui: {
+          components: {
+            A: {
+              'template.hbs': '<div>Hello</div>'
+            },
 
-              B: {
-                'template.hbs': 'From B: <A @foo={{bar}} /> {{@bar}}'
-              },
+            B: {
+              'template.hbs': 'From B: <A @foo={{bar}} /> {{@bar}}'
+            },
 
-              C: {
-                'template.hbs': 'From C'
-              },
+            C: {
+              'template.hbs': 'From C'
+            },
 
-              D: {
-                'template.hbs': '{{component C}}'
-              }
+            D: {
+              'template.hbs': '{{component C}}'
             }
           }
         }
@@ -160,17 +143,16 @@ module('Broccol Glimmer Bundle Compiler', function(hooks) {
     });
 
     let compiler = new GlimmerBundleCompiler(input.path(), {
-      projectPath: `${input.path()}/my-app`,
       delegate: TestModuleUnificationDelegate,
       outputFiles: {
-        dataSegment: 'my-app/src/data.js',
-        heapFile: 'my-app/src/templates.gbx'
+        dataSegment: 'src/data.js',
+        heapFile: 'src/templates.gbx'
       }
     });
 
     let output = await buildOutput(compiler);
     let files = output.read();
-    let dataSegment = files['my-app']['src']['data.js'];
+    let dataSegment = files['src']['data.js'];
     assert.ok(dataSegment.length > 0, 'data segment is populated');
     assert.ok(dataSegment.indexOf('table') > -1, 'has a table');
     assert.ok(dataSegment.indexOf('heap') > -1, 'has a heap');
@@ -180,14 +162,12 @@ module('Broccol Glimmer Bundle Compiler', function(hooks) {
 
   test('can lookup builtins', async function(assert) {
     input.write({
-      'my-app': {
-        'package.json': JSON.stringify({name: 'my-app'}),
-        src: {
-          ui: {
-            components: {
-              A: {
-                'template.hbs': '<div>Hello {{if true "wat"}}</div>'
-              }
+      'package.json': JSON.stringify({name: 'my-app'}),
+      src: {
+        ui: {
+          components: {
+            A: {
+              'template.hbs': '<div>Hello {{if true "wat"}}</div>'
             }
           }
         }
@@ -195,33 +175,30 @@ module('Broccol Glimmer Bundle Compiler', function(hooks) {
     });
 
     let compiler = new GlimmerBundleCompiler(input.path(), {
-      projectPath: `${input.path()}/my-app`,
       delegate: TestModuleUnificationDelegate,
       outputFiles: {
-        dataSegment: 'my-app/src/data.js',
-        heapFile: 'my-app/src/templates.gbx'
+        dataSegment: 'src/data.js',
+        heapFile: 'src/templates.gbx'
       }
     });
 
     let output = await buildOutput(compiler);
     let files = output.read();
-    let dataSegment = files['my-app']['src']['data.js'];
+    let dataSegment = files['src']['data.js'];
     assert.ok(dataSegment.indexOf('import { ifHelper as ') > -1);
   });
 
   test('can lookup custom builtins', async function(assert) {
     input.write({
-      'my-app': {
-        'package.json': JSON.stringify({name: 'my-app'}),
-        src: {
-          ui: {
-            components: {
-              A: {
-                'template.hbs': '<div>Hello {{css-blocks/state true "wat"}} {{if true "true"}} {{css-blocks/state true "huh"}}</div>'
-              },
-              B: {
-                'template.hbs': '<A /><p class={{css-blocks/style-if true "wat"}}>Red</p>'
-              }
+      'package.json': JSON.stringify({name: 'my-app'}),
+      src: {
+        ui: {
+          components: {
+            A: {
+              'template.hbs': '<div>Hello {{css-blocks/state true "wat"}} {{if true "true"}} {{css-blocks/state true "huh"}}</div>'
+            },
+            B: {
+              'template.hbs': '<A /><p class={{css-blocks/style-if true "wat"}}>Red</p>'
             }
           }
         }
@@ -229,7 +206,6 @@ module('Broccol Glimmer Bundle Compiler', function(hooks) {
     });
 
     let compiler = new GlimmerBundleCompiler(input.path(), {
-      projectPath: `${input.path()}/my-app`,
       delegate: TestModuleUnificationDelegate,
       builtins: {
         'css-blocks/style-if': { module: '@css-block/helpers/style-if', name: 'default' },
@@ -237,14 +213,14 @@ module('Broccol Glimmer Bundle Compiler', function(hooks) {
         'css-blocks/concat': { module: '@css-block/helpers/concat', name: 'default' }
       },
       outputFiles: {
-        dataSegment: 'my-app/src/data.js',
-        heapFile: 'my-app/src/templates.gbx'
+        dataSegment: 'src/data.js',
+        heapFile: 'src/templates.gbx'
       }
     });
 
     let output = await buildOutput(compiler);
     let files = output.read();
-    let dataSegment = files['my-app']['src']['data.js'];
+    let dataSegment = files['src']['data.js'];
     assert.ok(dataSegment.split('@css-block/helpers/state').length === 2);
     assert.ok(dataSegment.indexOf('@css-block/helpers/state') > -1);
     assert.ok(dataSegment.indexOf('@css-block/helpers/style-if') > -1);


### PR DESCRIPTION
This makes the broccoli plugin actually usable within an ember-cli project. Prior to this commit we assuming passing an entire project root into the plugin however in practice just the `src` directory will be used. This moves to an implicit assumption that the `inputPath` is the root of the project. This means the tree that is passed to the plugin must contain the package.json.