### PR TITLE
Use Glimmer.js version of UpdatableReference to avoid action volatility

### DIFF
--- a/packages/@glimmer/application/src/helpers/action.ts
+++ b/packages/@glimmer/application/src/helpers/action.ts
@@ -1,4 +1,4 @@
-import { UpdatableReference } from "@glimmer/object-reference";
+import { UpdatableReference } from "@glimmer/component";
 import { VM, Arguments } from "@glimmer/runtime";
 import { Opaque } from '@glimmer/interfaces';
 


### PR DESCRIPTION
The UpdatableReference provided by `@glimmer/object-reference` is volatile, and we were inadvertently using it to wrap values produced by the `{{action}}` helper.

This commit uses the version of UpdatableReference from `@glimmer/component`, which is stable until its underlying value is manually updated. This avoids significant performance degradation when values from `{{action}}` helpers are passed as args into other components.