### PR TITLE
Helpers should not be volatile

### DIFF
--- a/packages/@glimmer/application/src/application.ts
+++ b/packages/@glimmer/application/src/application.ts
@@ -114,9 +114,9 @@ export default class Application implements Owner {
   private _container: Container;
   private _initializers: Initializer[] = [];
   private _initialized = false;
-  private _rendering = false;
-  private _rendered = false;
-  private _scheduled = false;
+  protected _rendering = false;
+  protected _rendered = false;
+  protected _scheduled = false;
 
   protected builder: Builder;
   protected loader: Loader;

--- a/packages/@glimmer/application/src/helpers/user-helper.ts
+++ b/packages/@glimmer/application/src/helpers/user-helper.ts
@@ -5,7 +5,6 @@ import {
 
 import {
   PathReference,
-  Reference,
   TagWrapper,
   RevisionTag
 } from "@glimmer/reference";
@@ -17,30 +16,14 @@ import {
   VM
 } from "@glimmer/runtime";
 
+import {
+  RootReference
+} from '@glimmer/component';
+
 export type UserHelper = (args: ReadonlyArray<Opaque>, named: Dict<Opaque>) => any;
 
 export default function buildUserHelper(helperFunc): GlimmerHelper {
   return (_vm: VM, args: Arguments) => new HelperReference(helperFunc, args);
-}
-
-export class SimplePathReference<T> implements PathReference<T> {
-  private parent: Reference<T>;
-  private property: string;
-  public tag: TagWrapper<RevisionTag>;
-
-  constructor(parent: Reference<T>, property: string) {
-    this.parent = parent;
-    this.tag = parent.tag;
-    this.property = property;
-  }
-
-  value(): T {
-    return this.parent.value()[this.property];
-  }
-
-  get(prop: string): PathReference<Opaque> {
-    return new SimplePathReference(this, prop);
-  }
 }
 
 export class HelperReference implements PathReference<Opaque> {
@@ -60,7 +43,7 @@ export class HelperReference implements PathReference<Opaque> {
     return helper(args.positional.value(), args.named.value());
   }
 
-  get(prop: string): SimplePathReference<Opaque> {
-    return new SimplePathReference(this, prop);
+  get(): RootReference {
+    return new RootReference(this);
   }
 }

--- a/packages/@glimmer/application/src/helpers/user-helper.ts
+++ b/packages/@glimmer/application/src/helpers/user-helper.ts
@@ -6,8 +6,8 @@ import {
 import {
   PathReference,
   Reference,
-  VOLATILE_TAG,
-  TagWrapper
+  TagWrapper,
+  RevisionTag
 } from "@glimmer/reference";
 
 import {
@@ -26,10 +26,11 @@ export default function buildUserHelper(helperFunc): GlimmerHelper {
 export class SimplePathReference<T> implements PathReference<T> {
   private parent: Reference<T>;
   private property: string;
-  public tag: TagWrapper<null> = VOLATILE_TAG;
+  public tag: TagWrapper<RevisionTag>;
 
   constructor(parent: Reference<T>, property: string) {
     this.parent = parent;
+    this.tag = parent.tag;
     this.property = property;
   }
 
@@ -45,10 +46,11 @@ export class SimplePathReference<T> implements PathReference<T> {
 export class HelperReference implements PathReference<Opaque> {
   private helper: UserHelper;
   private args: CapturedArguments;
-  public tag: TagWrapper<null> = VOLATILE_TAG;
+  public tag: TagWrapper<RevisionTag>;
 
   constructor(helper: UserHelper, args: Arguments) {
     this.helper = helper;
+    this.tag = args.tag;
     this.args = args.capture();
   }
 


### PR DESCRIPTION
When references are combined to produce a single reference a volatile reference poisons the reference effectively making all the references to be re-validated. This removes the volatile references from user land helpers.