### PR TITLE
Unify Loader Interface

### DIFF
--- a/packages/@glimmer/application/src/application.ts
+++ b/packages/@glimmer/application/src/application.ts
@@ -49,7 +49,7 @@ export interface Loader {
   /**
    * Returns a template iterator for on the provided application state.
    */
-  getTemplateIterator(app: Application, env: Environment, builder: ElementBuilder, dynamicScope: DynamicScope, self: PathReference<Opaque>): TemplateIterator | Promise<TemplateIterator>;
+  getTemplateIterator(app: Application, env: Environment, builder: ElementBuilder, dynamicScope: DynamicScope, self: PathReference<Opaque>): Promise<TemplateIterator>;
 }
 
 /**

--- a/packages/@glimmer/application/src/loaders/runtime-compiler/loader.ts
+++ b/packages/@glimmer/application/src/loaders/runtime-compiler/loader.ts
@@ -27,7 +27,7 @@ export default class RuntimeCompilerLoader implements Loader {
   constructor(public resolver: Resolver) {
   }
 
-  getTemplateIterator(app: Application, env: Environment, builder: ElementBuilder, dynamicScope: DynamicScope, self: PathReference<Opaque>): TemplateIterator {
+  async getTemplateIterator(app: Application, env: Environment, builder: ElementBuilder, dynamicScope: DynamicScope, self: PathReference<Opaque>): Promise<TemplateIterator> {
     let resolver = new RuntimeResolver(app);
     let program = new Program(new LazyConstants(resolver));
     let macros = new Macros();
@@ -48,11 +48,11 @@ export default class RuntimeCompilerLoader implements Loader {
 
     let mainLayout = templateFactory(mainTemplate).create(compileOptions);
 
-    return mainLayout.renderLayout({
+    return Promise.resolve(mainLayout.renderLayout({
       env,
       builder,
       dynamicScope,
       self
-    });
+    }));
   }
 }

--- a/testem.js
+++ b/testem.js
@@ -15,7 +15,8 @@ let config = {
     "Chrome": [
       "--headless",
       "--disable-gpu",
-      "--remote-debugging-port=9222"
+      "--remote-debugging-port=9222",
+      "--no-sandbox"
     ]
   },
   "launch_in_dev": [


### PR DESCRIPTION
This makes getting the `TemplateIterator` have the same interface on the consuming side.