### PR TITLE
Fix CHANGELOG example to use SyncRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ of Glimmer.js 0.8.0, use the `DOMRenderer`, `RuntimeCompilerLoader`, and `SyncRe
 
 ```ts
 // src/main.ts
-import Application, { AsyncRenderer, DOMBuilder, RuntimeCompilerLoader } from '@glimmer/application';
+import Application, { DOMBuilder, RuntimeCompilerLoader, SyncRenderer } from '@glimmer/application';
 import Resolver, { BasicModuleRegistry } from '@glimmer/resolver';
 import moduleMap from '../config/module-map';
 import resolverConfiguration from '../config/resolver-configuration';
@@ -49,7 +49,7 @@ export default class App extends Application {
     super({
       builder: new DOMBuilder({ element, nextSibling: null }),
       loader: new RuntimeCompilerLoader(resolver),
-      renderer: new AsyncRenderer(),
+      renderer: new SyncRenderer(),
       resolver,
       rootName: resolverConfiguration.app.rootName,
     });


### PR DESCRIPTION
I meant to use `SyncRenderer` in the example, to preserve sync render semantics of upgrading 0.8.x apps.