### PR TITLE
Include handle in bytecode data segment metadata

### DIFF
--- a/packages/@glimmer/application-test-helpers/src/app-builder.ts
+++ b/packages/@glimmer/application-test-helpers/src/app-builder.ts
@@ -131,15 +131,14 @@ export class AppBuilder<T extends TestApplication> {
     let meta = {};
 
     table.vmHandleByModuleLocator.forEach((vmHandle, locator) => {
-      meta[locator.module] = { h: vmHandle };
-    });
+      let handle = table.byModuleLocator.get(locator);
+      let template = compiler.compilableTemplates.get(locator);
 
-    compiler.compilableTemplates.forEach((template, locator) => {
-      if (meta[locator.module]) {
-        meta[locator.module].table = template.symbolTable;
-      } else {
-        meta[locator.module] = { table: template.symbolTable };
-      }
+      meta[locator.module] = {
+        v: vmHandle,
+        h: handle,
+        table: template.symbolTable
+      };
     });
 
     table.byHandle.forEach((locator, handle) => {

--- a/packages/@glimmer/application/src/loaders/bytecode/loader.ts
+++ b/packages/@glimmer/application/src/loaders/bytecode/loader.ts
@@ -15,7 +15,11 @@ export interface SerializedHeap {
 }
 
 export interface Metadata {
+  /** VM handle */
+  v: number;
+  /** Handle */
   h: number;
+
   table: ProgramSymbolTable;
 }
 

--- a/packages/@glimmer/application/src/loaders/bytecode/resolver.ts
+++ b/packages/@glimmer/application/src/loaders/bytecode/resolver.ts
@@ -58,12 +58,15 @@ export default class BytecodeResolver implements RuntimeResolver<TemplateMeta> {
     let manager = this.managerFor();
 
     let templateSpecifier = owner.identify(`template:${name}`, referrer.specifier);
-    let trimmed = templateSpecifier.replace(this.prefix, '');
-    let vmHandle = this.meta[trimmed].h;
-    let symbolTable = this.meta[trimmed].table;
 
-    let componentSpecifier = owner.identify('component:', templateSpecifier);
-    let ComponentClass = componentSpecifier ? owner.factoryFor(componentSpecifier) : null;
+    if (!templateSpecifier) {
+      throw new Error(`Could not find component '${name}', invoked using the {{component}} helper in ${referrer.specifier}`);
+    }
+
+    let trimmed = templateSpecifier.replace(this.prefix, '');
+    let { v: vmHandle, h: handle, table: symbolTable } = this.meta[trimmed];
+
+    let ComponentClass = this.table[handle] as Factory<Opaque> || null;
 
     return buildComponentDefinition(ComponentClass, manager, vmHandle, symbolTable);
   }

--- a/packages/@glimmer/application/test/browser/application-test.ts
+++ b/packages/@glimmer/application/test/browser/application-test.ts
@@ -123,7 +123,8 @@ test('can be booted with bytecode loader', async function(assert) {
     mainEntry: result.table.vmHandleByModuleLocator.get(locator),
     meta: {
       'mainTemplate': {
-        h: result.table.vmHandleByModuleLocator.get(locator),
+        v: result.table.vmHandleByModuleLocator.get(locator),
+        h: result.table.byModuleLocator.get(locator),
         table: symbolTable
       }
     }

--- a/packages/@glimmer/compiler-delegates/test/node/module-unification-test.ts
+++ b/packages/@glimmer/compiler-delegates/test/node/module-unification-test.ts
@@ -69,10 +69,12 @@ test('heap table should be balanced', (assert) => {
 });
 
 test('can generate the specifier map', (assert) => {
-  table.vmHandleByModuleLocator.set({name: 'default', module: './src/ui/components/x/template.hbs' }, 0);
+  let locator = { name: 'default', module: './src/ui/components/x/template.hbs' };
+  table.vmHandleByModuleLocator.set(locator, 0);
+  table.byModuleLocator.set(locator, 100);
   let serializedTable = generator.generateSpecifierMap(table);
 
-  assert.deepEqual(serializedTable, {'template:/my-project/components/x': 0});
+  assert.deepEqual(serializedTable, {'template:/my-project/components/x': [0, 100]});
 });
 
 test('specifier\'s module path needs to be well formed', (assert) => {


### PR DESCRIPTION
Currently, we ship a JSON data structure with bytecode templates called `meta` that is keyed on specifier string and contains the component's VM handle and symbol table. This data structure supports dynamic lookup of components via the `{{component}}` helper, even though most component invocations are precompiled in bytecode mode.

However, we currently don't serialize each component's handle, which is an application-specific identifier. Handles are used to allow opcodes to refer to "live" JavaScript objects, like component classes, at runtime. While handles are built into the compiled bytecode, they are not accessible to dynamic component invocation. This means that Glimmer.js apps have to ship both the module resolution map as well as the template metadata just to get an app to boot, which is wasteful.

This commit adds each component's handle to its metadata entry in the compiled data segment. It also updates the `BytecodeResolver` to use the handle and external module table, so resolution happens identically to the static invocation path. In addition to this resolution being faster, it also means that Glimmer.js apps can boot without a resolution map and use the bytecode metadata for everything.