### PR TITLE
Support incremental rebuilds in @glimmer/app-compiler

### DIFF
--- a/packages/@glimmer/app-compiler/src/bundle-compiler.ts
+++ b/packages/@glimmer/app-compiler/src/bundle-compiler.ts
@@ -72,9 +72,7 @@ export default class GlimmerBundleCompiler extends Plugin {
   }
 
   build() {
-    if (!this.compiler && !this.delegate) {
-      this.createBundleCompiler();
-    }
+    this.createBundleCompiler();
 
     let { outputPath } = this;
 

--- a/packages/@glimmer/app-compiler/test/node/bundle-compiler-test.ts
+++ b/packages/@glimmer/app-compiler/test/node/bundle-compiler-test.ts
@@ -79,7 +79,7 @@ module('Broccol Glimmer Bundle Compiler', function(hooks) {
             },
 
             C: {
-              'template.hbs': 'From C'
+              'template.hbs': 'Hello From C'
             },
 
             D: {
@@ -100,6 +100,30 @@ module('Broccol Glimmer Bundle Compiler', function(hooks) {
     let buffer = new Uint16Array(files['src']['templates.gbx']);
 
     assert.ok(buffer, 'Buffer is aligned');
+    assert.ok((files['data-segment.js'] as string).match(/Hello From C/));
+
+    input.write({
+      src: {
+        ui: {
+          components: {
+            C: {
+              'template.hbs': 'Goodbye From C'
+            }
+          }
+        }
+      }
+    });
+
+    await output.build();
+
+    files = output.read();
+    buffer = new Uint16Array(files['src']['templates.gbx']);
+
+    assert.ok(buffer, 'Buffer is aligned');
+
+    let dataSegment = files['data-segment.js'] as string;
+    assert.ok(dataSegment.match(/Goodbye From C/), "string constants should contain updated template contents");
+    assert.ok(!(dataSegment.match(/Hello From C/)), "string constants should not contain old content");
   });
 
   test('data segment has all segments', async function(assert) {


### PR DESCRIPTION
This PR solves one of the hardest problems in computer science. The BundleCompiler from Glimmer VM is stateful and is only intended to be used for one-shot compilation. Unfortunately the current implementation of the app compiler caches the bundle compiler across rebuilds, meaning that you have to start and stop the Broccoli server to see changes. This commit changes the implementation to create a fresh compiler/delegate every rebuild.