### PR TITLE
Add lint:ts to npm scripts to app blueprint

### DIFF
--- a/packages/@glimmer/blueprint/files/package.json
+++ b/packages/@glimmer/blueprint/files/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "ember build -prod",
     "start": "ember server",
-    "test": "ember test"
+    "test": "ember test",
+    "lint:ts": "tslint -c tslint.json 'src/**/*.ts' -t codeFrame"
   },
   "devDependencies": {
     "@glimmer/application": "^0.9.1",


### PR DESCRIPTION
Recently the same was added to the default blueprint of Ember apps, so I think it makes sense to add here as well.