### PR TITLE
Use WeakMap for storing Glimmer metadata

### DIFF
--- a/build/broccoli/build-tests.js
+++ b/build/broccoli/build-tests.js
@@ -64,7 +64,7 @@ function includeTests(jsTree) {
 
   return new Rollup(testsRoot, {
     rollup: {
-      format: 'es',
+      format: 'iife',
       entry: ['tests.js'],
       dest: 'assets/tests.js',
       plugins: [


### PR DESCRIPTION
**TL;DR**
* Use `WeakMap` instead of symbols to store tracked property metadata.
* Fix the tests to run in strict mode, so mutating a frozen object actually throws an error. :trollface: 

Tracked properties rely on storing unique tags for each property on an object. We store these and other metadata in instances of a class called Meta, which are created lazily the first time a tracked property is requested for a property on an object.

Prior to this PR, we used a symbol to store the object's Meta on itself. The symbol prevented inadvertent access or naming collisions. However, when in strict mode, setting a property throws an error if the object in question is frozen via `Object.freeze`. It is a common pattern for libraries to use `Object.freeze` on objects that should be read-only, such as Apollo (https://github.com/glimmerjs/glimmer-vm/issues/632). Simply rendering a property from a frozen object in a template should not cause an exception to be thrown.

To fix this, this commit changes the implementation to use a WeakMap to map objects to their corresponding Meta instance. The new implementation is intended to be semantically identical to the previous implementation, but with compatibility with frozen objects.

This PR contains another important change. We have dealt with issues with frozen objects in the past, and even wrote quite a few tests to verify compatibility with them.

Unfortunately, due to a misconfiguration I made to the Rollup builds, our test suite was not actually running in strict mode. This meant that all of the tests testing frozen objects were invalid, because in sloppy mode, mutating a frozen object does not throw an error.

This PR changes the Rollup configuration to use the `iife` format rather than `es`, which puts them into strict mode. After I made this change, previously passing tests began to fail. However, they are addressed by the move to WeakMaps.