### PR TITLE
Adds regression test for issue #132 which appears fixed on master

### DIFF
--- a/packages/@glimmer/component/test/browser/component-test.ts
+++ b/packages/@glimmer/component/test/browser/component-test.ts
@@ -25,3 +25,15 @@ test('can be instantiated with an owner', async function(assert) {
   assert.ok(component, 'component exists');
   assert.strictEqual(getOwner(component), app, 'owner has been set');
 });
+
+test('can yield named args to the block', async function(assert) {
+  let app = await buildApp()
+    .helper('hash', (params, named) => named)
+    .template('Main', '<YieldsHash as |x|>I have {{x.number}} {{x.string}}</YieldsHash>')
+    .template('YieldsHash', '<div>{{yield (hash string="bananas" number=5)}}</div>')
+    .boot();
+
+  let root = app.rootElement as HTMLElement;
+
+  assert.equal(root.innerText, 'I have 5 bananas');
+});


### PR DESCRIPTION
As per @lifeart's request, I am adding this test for a broken syntax in v0.9.1 (It is now fixed in `master`). Referenced in issue #132.

I do not know if this is the best place for this test, so suggestions are welcome.

(I did check the test at the v0.9.1 tag, and it fails there.)