### PR TITLE
Bump glimmer-application-pipeline dependency

### DIFF
--- a/packages/@glimmer/blueprint/files/package.json
+++ b/packages/@glimmer/blueprint/files/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@glimmer/application": "^0.12.0",
-    "@glimmer/application-pipeline": "^0.11.2",
+    "@glimmer/application-pipeline": "^0.11.3",
     "@glimmer/blueprint": "~<%= blueprintVersion %>",
     "@glimmer/component": "^0.12.0",
     "@glimmer/inline-precompile": "^1.0.0",

--- a/packages/@glimmer/blueprint/files/package.json
+++ b/packages/@glimmer/blueprint/files/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@glimmer/application": "^0.12.0",
-    "@glimmer/application-pipeline": "^0.11.3",
+    "@glimmer/application-pipeline": "^0.13.0",
     "@glimmer/blueprint": "~<%= blueprintVersion %>",
     "@glimmer/component": "^0.12.0",
     "@glimmer/inline-precompile": "^1.0.0",

--- a/packages/@glimmer/blueprint/files/package.json
+++ b/packages/@glimmer/blueprint/files/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@glimmer/application": "^0.12.0",
-    "@glimmer/application-pipeline": "^0.10.0",
+    "@glimmer/application-pipeline": "^0.11.2",
     "@glimmer/blueprint": "~<%= blueprintVersion %>",
     "@glimmer/component": "^0.12.0",
     "@glimmer/inline-precompile": "^1.0.0",

--- a/packages/@glimmer/blueprint/files/testem.json
+++ b/packages/@glimmer/blueprint/files/testem.json
@@ -1,7 +1,5 @@
 {
-  "framework": "qunit",
-  "src_files": ["src/**/*"],
-  "serve_files": ["index.js"],
+  "test_page": "tests/index.html",
   "disable_watching": true,
   "launch_in_ci": ["Firefox", "Chrome"]
 }

--- a/packages/@glimmer/blueprint/files/tests/index.html
+++ b/packages/@glimmer/blueprint/files/tests/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Glimmer PDP Viewer Tests</title>
+    <title><%= name %></title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.6.2.css">
-    <script src="https://code.jquery.com/qunit/qunit-2.6.2.js"></script>
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.8.0.css">
+    <script src="https://code.jquery.com/qunit/qunit-2.8.0.js"></script>
     <script src="/testem.js"></script>
     <script src="./index.js"></script>
   </head>

--- a/packages/@glimmer/blueprint/files/tests/index.html
+++ b/packages/@glimmer/blueprint/files/tests/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Glimmer PDP Viewer Tests</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.6.2.css">
+    <script src="https://code.jquery.com/qunit/qunit-2.6.2.js"></script>
+    <script src="/testem.js"></script>
+    <script src="./index.js"></script>
+  </head>
+
+  <body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="app"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
[Edit from latest commit]

The following is meant to satisfy the PR in glimmer application pipeline
found here:

glimmerjs/glimmer-application-pipeline#152

That PR takes the output from the `<glimmerAppRoot>/tests/index.html`
and bundles it with the appropriate testEntryPoint in the dist after a
build.

(Sidenote: it does this in all non production environments
rather than just test)

In order for the process for new Glimmer apps to be smooth we need to
utilize that PR (from glimmer application pipeline) and then also do the
following (implemented in this PR):

- Bump package version of glimmer-application-pipeilne (the assumption
of this PR is that when we release glimmer-application-pipeline it will
be bumped as a patch version to 0.11.3
- Add the default `tests/index.html` to the root of the project.  This
is what will be used by glimmer-application-pipeline
   - *note here* it uses a CDN url for QUnit because that is easier in a
   future PR we'll have glimmer-application-pipeline handle this such
   that it is available in the dist
- Finally we must update the testem.json to point to `tests/index.html`
which (as a result of how ember-cli works) is relative to the `dist`
folder already.

---

The benefits of this is that we can get a modern version of QUnit.
Until this point new glimmer applications could only have 1 function
that consumes the `hooks` per module which is stifling for a number of
reasons.  Furthermore, this PR (and its associated
glimmer-application-pipeline PR) bring glimmer applications closer to
the harness of Ember itself.