### PR TITLE
Fixed ESLint issue with component-test blueprint

### DIFF
--- a/packages/@glimmer/blueprint/files/src/ui/components/__component__/component-test.ts
+++ b/packages/@glimmer/blueprint/files/src/ui/components/__component__/component-test.ts
@@ -1,5 +1,5 @@
 import hbs from '@glimmer/inline-precompile';
-import { setupRenderingTest } from '@glimmer/test-helpers';
+import { render, setupRenderingTest } from '@glimmer/test-helpers';
 
 const { module, test } = QUnit;
 
@@ -7,7 +7,7 @@ module('Component: <%= component %>', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    await this.render(hbs`<<%= component %> />`);
+    await render(hbs`<<%= component %> />`);
     assert.equal(this.containerElement.textContent, 'Welcome to Glimmer!\n');
   });
 });


### PR DESCRIPTION
There is ESLint issue with files generated by @glimmer/blueprint. "component-test.ts" generated by this blueprint uses "this.render". I have changed "this.render" to "render", which is also used in https://github.com/glimmerjs/glimmer-application-pipeline/blob/master/blueprints/glimmer-component-test/files/src/ui/components/__name__/component-test.ts