### PR TITLE
turn off: Requires interface names to begin with a capital ‘I’

### DIFF
--- a/packages/@glimmer/blueprint/files/tslint.json
+++ b/packages/@glimmer/blueprint/files/tslint.json
@@ -8,7 +8,8 @@
     "quotemark": [true, "single"],
     "trailing-comma": false,
     "only-arrow-functions": false,
-    "prefer-const": false
+    "prefer-const": false,
+    "interface-name": [true, "never-prefix"]
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
Defaulting to expect people to prefix all their interfaces with a capital `I` feels extreme because whatever name I choose for my interfaces, they will:
 - only appear in the signature of a function
 - the declaration of a variable
 - use upper case for the first letter of each word
 - many modern editors will highlight it with a different color

So, adding an `I` doesn't seem to contribute much more to the intention of making it very clear that the name is referring to a TypeScript interface. It is overkill and it forces you to use weird names that can't be pronounce, verbally or mentally, easily.