### PR TITLE
Fixed broken tests from glimmer-vm update; fix passing of dynamicScope

### DIFF
--- a/packages/@glimmer/application/src/loaders/bytecode/loader.ts
+++ b/packages/@glimmer/application/src/loaders/bytecode/loader.ts
@@ -84,7 +84,7 @@ export default class BytecodeLoader implements Loader {
     const { mainEntry } = this.data;
     const runtime = await this.getRuntime(app, env);
 
-    return renderAotMain(runtime, self, builder, mainEntry);
+    return renderAotMain(runtime, self, builder, mainEntry, dynamicScope);
   }
 
   async getComponentTemplateIterator(


### PR DESCRIPTION
- Fixed broken tests for `MUCompilerDelegate`
- Open up passing of `dynamicScope` to renderAoTMain, to allow for custom implementations of rendering environment.