### PR TITLE
Better setPropertyDidChange error message

### DIFF
--- a/packages/@glimmer/component/index.ts
+++ b/packages/@glimmer/component/index.ts
@@ -9,5 +9,6 @@ export {
 } from './src/references';
 export { default as TemplateMeta } from './src/template-meta';
 export { CAPABILITIES } from './src/capabilities';
+export { setPropertyDidChange } from './src/deprecations';
 
 export { tracked } from '@glimmer/tracking';

--- a/packages/@glimmer/component/src/deprecations.ts
+++ b/packages/@glimmer/component/src/deprecations.ts
@@ -1,0 +1,7 @@
+// This function has been moved to the @glimmer/tracking package. Catch uses of
+// the old API and ensure users get a nice error message.
+export function setPropertyDidChange() {
+  throw new Error(
+    `The setPropertyDidChange function has moved to the @glimmer/tracking package. Please update your import to:\n\timport { setPropertyDidChange } from '@glimmer/tracking'`
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5244,6 +5244,7 @@ estree-walker@^0.3.0:
 estree-walker@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
+  integrity sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -5834,6 +5835,7 @@ fs-exists-sync@^0.1.0:
 fs-extra@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
+  integrity sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -9660,6 +9662,7 @@ resolve@1.5.0:
 resolve@1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
+  integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
   dependencies:
     path-parse "^1.0.5"
 
@@ -9749,6 +9752,7 @@ rollup-plugin-sourcemaps@^0.4.2:
 rollup-plugin-typescript2@^0.17.0:
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.17.0.tgz#a540eecfe9ad8ff5e8e86eaf5069bb2a7f84f33a"
+  integrity sha512-QB6Ii+HVAdmNwjlCay7gLrddoNtquLT4cECg7wynK3XQ9k6ebsd1Km09Tbpcm+WHBjMZqeDZGFmzny57NTfkmg==
   dependencies:
     fs-extra "7.0.0"
     resolve "1.8.1"
@@ -9763,6 +9767,7 @@ rollup-plugin-virtual@^1.0.1:
 rollup-pluginutils@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.1.tgz#760d185ccc237dedc12d7ae48c6bcd127b4892d0"
+  integrity sha512-JZS8aJMHEHhqmY2QVPMXwKP6lsD1ShkrcGYjhAIvqKKdXQyPHw/9NF0tl3On/xOJ4ACkxfeG7AF+chfCN1NpBg==
   dependencies:
     estree-walker "^0.5.2"
     micromatch "^2.3.11"
@@ -10911,6 +10916,7 @@ trim-right@^1.0.1:
 tslib@1.9.3, tslib@^1.7.1, tslib@^1.8.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tslib@^1.8.0:
   version "1.9.0"


### PR DESCRIPTION
In previous versions, we exported `setPropertyDidChange` from `@glimmer/component`. In 0.14, this has been moved to the `@glimmer/tracking` package. To help people upgrading from older versions of Glimmer.js, this PR adds a stub `setPropertyDidChange` function back to the old location, but has it raise an error with a more helpful error message guiding users on how to refactor to the new location.