### PR TITLE
Re-enable lifecycle hooks for Glimmer.js environments

### DIFF
--- a/packages/@glimmer/component/src/bounds.ts
+++ b/packages/@glimmer/component/src/bounds.ts
@@ -1,0 +1,22 @@
+import { Bounds as VMBounds } from '@glimmer/interfaces';
+
+/**
+ * Contains the first and last DOM nodes in a component's rendered
+ * template. These nodes can be used to traverse the section of DOM
+ * that belongs to a particular component.
+ *
+ * Note that these nodes *can* change over the lifetime of a component
+ * if the beginning or ending of the template is dynamic.
+ */
+export default class Bounds {
+  constructor(private _bounds: VMBounds) {
+  }
+
+  get firstNode(): Node {
+    return this._bounds.firstNode() as Node;
+  }
+
+  get lastNode(): Node {
+    return this._bounds.lastNode() as Node;
+  }
+}

--- a/packages/@glimmer/component/src/component-manager.ts
+++ b/packages/@glimmer/component/src/component-manager.ts
@@ -16,12 +16,14 @@ import {
   JitRuntimeResolver,
   AotRuntimeResolver,
   CompilableProgram,
+  Bounds as VMBounds,
 } from '@glimmer/interfaces';
 import { VersionedPathReference, PathReference, CONSTANT_TAG } from '@glimmer/reference';
 import { DEBUG } from '@glimmer/env';
 
 import Component from './component';
 import { DefinitionState } from './component-definition';
+import Bounds from './bounds';
 import { RootReference, TemplateOnlyComponentDebugReference } from './references';
 import ExtendedTemplateMeta from './template-meta';
 import { SerializedTemplateWithLazyBlock } from '@glimmer/application/src/loaders/runtime-compiler/resolver';
@@ -186,9 +188,25 @@ export default class ComponentManager
 
   didCreateElement(bucket: ComponentStateBucket, element: HTMLElement) {}
 
-  didRenderLayout() {}
+  didRenderLayout(bucket: ComponentStateBucket, bounds: VMBounds) {
+    if (DEBUG && bucket instanceof TemplateOnlyComponentDebugBucket) {
+      return;
+    }
+    if (!bucket) {
+      return;
+    }
+    bucket.component.bounds = new Bounds(bounds);
+  }
 
-  didCreate() {}
+  didCreate(bucket: ComponentStateBucket) {
+    if (DEBUG && bucket instanceof TemplateOnlyComponentDebugBucket) {
+      return;
+    }
+    if (!bucket) {
+      return;
+    }
+    bucket.component.didInsertElement();
+  }
 
   getTag(bucket: ComponentStateBucket): Tag {
     if (DEBUG && bucket instanceof TemplateOnlyComponentDebugBucket) {

--- a/packages/@glimmer/component/src/component.ts
+++ b/packages/@glimmer/component/src/component.ts
@@ -2,6 +2,12 @@ import { metaFor, trackedGet } from '@glimmer/tracking';
 import { CURRENT_TAG } from '@glimmer/reference';
 
 import GlimmerComponent from '../addon/-private/component';
+import { assert } from '@glimmer/util';
+
+export interface Bounds {
+  firstNode: Node;
+  lastNode: Node;
+}
 
 export default class Component extends GlimmerComponent<any> {
   get args() {
@@ -21,10 +27,6 @@ export default class Component extends GlimmerComponent<any> {
    */
   private __args__: any;
 
-  // static create(injections: any) {
-  //   return new this(injections);
-  // }
-
   /**
    * Development-mode only name of the component, useful for debugging.
    */
@@ -32,6 +34,124 @@ export default class Component extends GlimmerComponent<any> {
 
   toString() {
     return `${this.debugName} component`;
+  }
+
+  /*
+   * Legacy DOM access and lifecycle hooks. These will be deprecated in favor
+   * of render modifiers once Glimmer.js supports an element modifier manager
+   * API.
+  */
+
+  /**
+   * Called when the component has been inserted into the DOM.
+   * Override this function to do any set up that requires an element in the document body.
+   */
+  didInsertElement() { }
+
+  /**
+   * Called when the component has updated and rerendered itself.
+   * Called only during a rerender, not during an initial render.
+   */
+  didUpdate() { }
+
+  /**
+   * Contains the first and last DOM nodes of a component's rendered template.
+   * These nodes can be used to traverse all of the DOM nodes that belong to a
+   * particular component.
+   *
+   * Note that a component's first and last nodes *can* change over time, if the
+   * beginning or ending of the template is dynamic. You should always access
+   * `bounds` directly at the time a node is needed to ensure you are acting on
+   * up-to-date nodes.
+   *
+   * ### Examples
+   *
+   * For components with a single root element, `this.bounds.firstNode` and
+   * `this.bounds.lastNode` are the same.
+   *
+   * ```hbs
+   * <div class="user-profile">
+   *   <Avatar @user={{user}} />
+   * </div>
+   * ```
+   *
+   * ```ts
+   * export default class extends Component {
+   *   didInsertElement() {
+   *     let { firstNode, lastNode } = this.bounds;
+   *     console.log(firstNode === lastNode); // true
+   *     console.log(firstNode.className); // "user-profile"
+   *   }
+   * }
+   * ```
+   *
+   * For components with multiple root nodes, `this.bounds.firstNode` refers to
+   * the first node in the template and `this.bounds.lastNode` refers to the
+   * last:
+   *
+   * ```hbs
+   * Welcome to Glimmer.js!
+   * <span>Let's build some components!</span>
+   * <img src="logo.png">
+   * ```
+   *
+   * ```ts
+   * export default class extends Component {
+   *   didInsertElement() {
+   *     let { firstNode, lastNode } = this.bounds;
+   *
+   *     // Walk all of the DOM siblings from the
+   *     // firstNode to the lastNode and push their
+   *     // nodeName into an array.
+   *     let node = firstNode;
+   *     let names = [firstNode.nodeName];
+   *     do {
+   *       node = node.nextSibling;
+   *       names.push(node.nodeName);
+   *     } while (node !== lastNode);
+   *
+   *     console.log(names);
+   *     // ["#text", "SPAN", "IMG"]
+   *   }
+   * }
+   * ```
+   *
+   * The bounds can change if the template has dynamic content at the beginning
+   * or the end:
+   *
+   * ```hbs
+   * {{#if user.isAdmin}}
+   *   <span class="warning">Admin</span>
+   * {{else}}
+   *   Normal User
+   * {{/if}}
+   * ```
+   *
+   * In this example, the `firstNode` will change between a `span` element and a
+   * `TextNode` as the `user.isAdmin` property changes.
+   */
+  bounds: Bounds;
+
+  /**
+   * The element corresponding to the main element of the component's template.
+   * The main element is the element in the template that has `...attributes` set on it:
+   *
+   * ```hbs
+   * <h1>Modal</h1>
+   * <div class="contents" ...attributes>
+   *   {{yield}}
+   * </div>
+   * ```
+   *
+   * In this example, `this.element` would be the `div` with the class `contents`.
+   *
+   * You should not try to access this property until after the component's `didInsertElement()`
+   * lifecycle hook is called.
+   */
+  get element(): HTMLElement {
+    let { bounds } = this;
+    assert(bounds && bounds.firstNode === bounds.lastNode, `The 'element' property can only be accessed on components that contain a single root element in their template. Try using 'bounds' instead to access the first and last nodes.`);
+    return bounds.firstNode as HTMLElement;
   }
 }
 


### PR DESCRIPTION
This commit restores the `didInsertElement` and `didUpdate` lifecycle hooks and `element`/`bounds` properties that were removed during the work to enable @glimmer/component to work as an Ember addon.

Our intent is for developers to use an element modifier-based API to access the DOM, rather than component hooks and properties. This is supported in the Ember environment today. However, the required element modifier manager API is not yet implemented in Glimmer.js.

Not having this capability blocks many Glimmer.js apps from upgrading, so this commit restores that functionality and allows those apps to upgrade to 0.14. Once we implement element modifier manager support in Glimmer.js, we can re-remove these APIs and align the Glimmer/Ember environments.