### PR TITLE
Fix TS strict mode errors in @glimmer/application

### DIFF
--- a/packages/@glimmer/application/src/base-application.ts
+++ b/packages/@glimmer/application/src/base-application.ts
@@ -124,10 +124,10 @@ export interface BaseApplicationOptions {
 export default abstract class BaseApplication implements Owner {
   public rootName: string;
   public resolver: Resolver;
-  readonly document: SimpleDocument;
+  readonly document!: SimpleDocument;
 
-  private _registry: Registry;
-  private _container: Container;
+  private _registry!: Registry;
+  private _container!: Container;
   private _initializers: Initializer[] = [];
   private _environment: FactoryDefinition<Environment>;
 

--- a/packages/@glimmer/application/src/environment.ts
+++ b/packages/@glimmer/application/src/environment.ts
@@ -20,7 +20,7 @@ export interface EnvironmentOptions {
 /** @internal */
 export default class EnvironmentImpl extends GlimmerEnvironmentImpl implements Environment {
   private uselessAnchor: HTMLAnchorElement;
-  public resolver: RuntimeResolver;
+  public resolver!: RuntimeResolver;
 
   static create(options: Partial<EnvironmentOptions> = {}) {
     options.document = options.document || self.document;

--- a/packages/@glimmer/application/src/helpers/user-helper.ts
+++ b/packages/@glimmer/application/src/helpers/user-helper.ts
@@ -11,7 +11,7 @@ export default function buildUserHelper(helperFunc: UserHelper): GlimmerHelper {
 }
 
 export class HelperReference extends CachedReference<unknown> {
-  public tag: TagWrapper<RevisionTag>;
+  public tag: TagWrapper<RevisionTag | null>;
   private args: CapturedArguments;
 
   constructor(private helper: UserHelper, args: VMArguments) {

--- a/packages/@glimmer/application/src/iterable.ts
+++ b/packages/@glimmer/application/src/iterable.ts
@@ -26,7 +26,7 @@ class ArrayIterator implements OpaqueIterator {
     return this.array.length === 0;
   }
 
-  next(): IterationItem<unknown, number> {
+  next(): IterationItem<unknown, number> | null {
     let { position, array, keyFor } = this;
 
     if (position >= array.length) return null;
@@ -57,7 +57,7 @@ class ObjectKeysIterator implements OpaqueIterator {
     return this.keys.length === 0;
   }
 
-  next(): IterationItem<unknown, string> {
+  next(): IterationItem<unknown, string> | null {
     let { position, keys, values, keyFor } = this;
 
     if (position >= keys.length) return null;
@@ -94,7 +94,7 @@ export function iterableFor(ref: Reference<unknown>, keyPath: string): OpaqueIte
 
   switch (keyPath) {
     case '@index':
-      keyFor = (_, index: number) => String(index);
+      keyFor = (_, index: unknown) => String(index);
       break;
     case '@primitive':
       keyFor = (item: unknown) => String(item);

--- a/packages/@glimmer/application/src/loaders/bytecode/loader.ts
+++ b/packages/@glimmer/application/src/loaders/bytecode/loader.ts
@@ -22,7 +22,7 @@ export interface SerializedHeap {
 }
 
 export interface Metadata {
-  [key: string]: number | ProgramSymbolTable;
+  [key: string]: number | ProgramSymbolTable | undefined;
 
   /** VM handle */
   v?: number;

--- a/packages/@glimmer/application/src/renderers/async-renderer.ts
+++ b/packages/@glimmer/application/src/renderers/async-renderer.ts
@@ -51,7 +51,7 @@ const DEFAULT_TIMEOUT = 250;
  */
 export default class AsyncRenderer implements Renderer {
   public timeout: number;
-  protected result: RenderResult;
+  protected result: RenderResult | null = null;
 
   constructor(options: AsyncRendererOptions = {}) {
     this.timeout = options.timeout || DEFAULT_TIMEOUT;
@@ -62,14 +62,14 @@ export default class AsyncRenderer implements Renderer {
       let timeout = this.timeout;
 
       let tick = (deadline: Deadline) => {
-        let iteratorResult: IteratorResult<RenderResult>;
+        let iteratorResult: IteratorResult<RenderResult | null>;
 
         do {
           iteratorResult = iterator.next();
         } while (!iteratorResult.done && deadline.timeRemaining() > 1);
 
         if (iteratorResult.done) {
-          this.result = iteratorResult.value;
+          this.result = iteratorResult.value!;
           return resolve();
         }
 

--- a/packages/@glimmer/application/src/renderers/sync-renderer.ts
+++ b/packages/@glimmer/application/src/renderers/sync-renderer.ts
@@ -18,7 +18,7 @@ import { RenderResult, TemplateIterator } from '@glimmer/interfaces';
  * @public
  */
 export default class SyncRenderer implements Renderer {
-  result: RenderResult;
+  result: RenderResult | null = null;
 
   render(iterator: TemplateIterator): void {
     // Iterate the template iterator, executing the compiled template program

--- a/packages/@glimmer/application/src/templates/main.d.ts
+++ b/packages/@glimmer/application/src/templates/main.d.ts
@@ -1,5 +1,5 @@
 import { SerializedTemplateWithLazyBlock } from '@glimmer/interfaces';
 
-declare const _default: SerializedTemplateWithLazyBlock;
+declare const _default: SerializedTemplateWithLazyBlock<unknown>;
 
 export default _default;

--- a/packages/@glimmer/application/test/browser/action-test.ts
+++ b/packages/@glimmer/application/test/browser/action-test.ts
@@ -18,7 +18,7 @@ test('can curry arguments to actions', async function(assert) {
     @tracked
     name = 'world';
 
-    constructor(owner, args) {
+    constructor(owner: any, args: any) {
       super(owner, args);
       helloWorldComponent = this;
     }
@@ -41,20 +41,20 @@ test('can curry arguments to actions', async function(assert) {
   assert.strictEqual(root.innerText, 'Hello World');
 
   let h1 = root.querySelector('h1');
-  h1.onclick(fakeEvent);
+  h1!.onclick!(fakeEvent);
 
   assert.strictEqual(passedMsg1, 'hello');
   assert.strictEqual(passedMsg2, 'world');
   assert.strictEqual(passedEvent, fakeEvent);
   passedEvent = null;
 
-  helloWorldComponent.name = 'cruel world';
+  helloWorldComponent!.name = 'cruel world';
   app.scheduleRerender();
 
   await didRender(app);
 
   h1 = root.querySelector('h1');
-  h1.onclick(fakeEvent);
+  h1!.onclick!(fakeEvent);
 
   assert.strictEqual(passedMsg1, 'hello');
   assert.strictEqual(passedMsg2, 'cruel world');
@@ -73,7 +73,7 @@ test('actions can be passed and invoked with additional arguments', async functi
   class ParentComponent extends Component {
     name = 'world';
 
-    constructor(owner, args) {
+    constructor(owner: any, args: any) {
       super(owner, args);
       parentComponent = this;
     }
@@ -103,7 +103,7 @@ test('actions can be passed and invoked with additional arguments', async functi
   let root = app.rootElement as Element;
 
   let h1 = root.querySelector('.grandchild') as HTMLElement;
-  h1.onclick(fakeEvent);
+  h1!.onclick!(fakeEvent);
 
   assert.deepEqual(passed, [1, 2, 3, 4, 5, 6, fakeEvent]);
 });

--- a/packages/@glimmer/application/test/browser/application-as-owner-test.ts
+++ b/packages/@glimmer/application/test/browser/application-as-owner-test.ts
@@ -43,7 +43,7 @@ test('#factoryFor - returns a registered factory', function(assert) {
   let app = createApp({ rootName: 'app', resolver: new BlankResolver() });
 
   app.registerInitializer({
-    initialize(app) {
+    initialize(app: any) {
       app.register('component:/app/components/date-picker', DatePicker);
     },
   });
@@ -123,7 +123,7 @@ test('#factoryFor - will use a resolver to locate a factory, even if one is regi
 
   let app = createApp({ rootName: 'app', resolver });
   app.registerInitializer({
-    initialize(app) {
+    initialize(app: any) {
       app.register('foo:/app/foos/bar', Foo);
     },
   });
@@ -149,7 +149,7 @@ test('#lookup - returns an instance created by the factory', function(assert) {
 
   let app = createApp({ rootName: 'app', resolver: new BlankResolver() });
   app.registerInitializer({
-    initialize(app) {
+    initialize(app: any) {
       app.register('foo:/app/foos/bar', FooBar);
     },
   });
@@ -174,7 +174,7 @@ test('#lookup - caches looked up instances by default', function(assert) {
 
   let app = createApp({ rootName: 'app', resolver: new BlankResolver() });
   app.registerInitializer({
-    initialize(app) {
+    initialize(app: any) {
       app.register('foo:/app/foos/bar', FooBar);
     },
   });
@@ -203,7 +203,7 @@ test('#lookup - will not cache lookups specified as non-singletons', function(as
 
   let app = createApp({ rootName: 'app', resolver: new BlankResolver() });
   app.registerInitializer({
-    initialize(app) {
+    initialize(app: any) {
       app.register('foo:/app/foos/bar', FooBar, { singleton: false });
     },
   });
@@ -224,7 +224,7 @@ test('#lookup - returns the factory when registrations specify instantiate: fals
 
   let app = createApp({ rootName: 'app', resolver: new BlankResolver() });
   app.registerInitializer({
-    initialize(app) {
+    initialize(app: any) {
       app.register('foo:/app/foos/bar', factory, { instantiate: false });
     },
   });
@@ -292,7 +292,7 @@ test('#lookup - injects references registered by name', function(assert) {
   let app = createApp({ rootName: 'app', resolver: new BlankResolver() });
 
   app.registerInitializer({
-    initialize(app) {
+    initialize(app: any) {
       app.register('foo:/app/foos/bar', FooBar);
       app.register('router:/app/root/main', Router);
       app.registerInjection('foo:/app/foos/bar', 'router', 'router:/app/root/main');
@@ -330,7 +330,7 @@ test('#lookup - injects references registered by type', function(assert) {
   let app = createApp({ rootName: 'app', resolver: new BlankResolver() });
 
   app.registerInitializer({
-    initialize(app) {
+    initialize(app: any) {
       app.register('foo:/app/foos/bar', FooBar);
       app.register('router:/app/root/main', Router);
       app.registerInjection('foo:/app/foos/bar', 'router', 'router:/app/root/main');

--- a/packages/@glimmer/application/test/browser/application-test.ts
+++ b/packages/@glimmer/application/test/browser/application-test.ts
@@ -78,7 +78,7 @@ test('can be booted with bytecode loader', async function(assert) {
     },
     pool: result.pool,
     table: [],
-    mainEntry: result.table.vmHandleByModuleLocator.get(locator),
+    mainEntry: result.table.vmHandleByModuleLocator.get(locator)!,
     meta: {
       mainTemplate: {
         v: result.table.vmHandleByModuleLocator.get(locator),

--- a/packages/@glimmer/application/test/browser/environment-test.ts
+++ b/packages/@glimmer/application/test/browser/environment-test.ts
@@ -123,7 +123,7 @@ test('custom elements are rendered', async function(assert) {
 
 test('components without a template raise an error', async function(assert) {
   class HelloWorldComponent extends Component {
-    debugName: 'HelloWorld';
+    debugName = 'HelloWorld';
   }
 
   let app = await buildApp()
@@ -141,7 +141,7 @@ test('components without a template raise an error', async function(assert) {
 
 test('components with dasherized names raise an error', function(assert) {
   class HelloWorldComponent extends Component {
-    debugName: 'hello-world';
+    debugName = 'hello-world';
   }
 
   assert.throws(() => {

--- a/packages/@glimmer/application/test/browser/render-component-test.ts
+++ b/packages/@glimmer/application/test/browser/render-component-test.ts
@@ -138,11 +138,11 @@ class RenderComponentTest extends RenderTest {
 
     containerElement.appendChild(nextSibling);
 
-    let component;
+    let component: any;
 
     class HelloWorld extends Component {
       @tracked a = 'a';
-      constructor(owner, args) {
+      constructor(owner: any, args: any) {
         super(owner, args);
         component = this;
       }

--- a/packages/@glimmer/application/test/initializers-test.ts
+++ b/packages/@glimmer/application/test/initializers-test.ts
@@ -20,6 +20,7 @@ test('instance initializers run at initialization', function(assert) {
     loader: new RuntimeCompilerLoader(resolver),
     builder: new DOMBuilder({ element }),
     renderer: new SyncRenderer(),
+    document: {} as any,
     resolver,
   });
   app.registerInitializer({

--- a/packages/@glimmer/application/test/iterable-test.ts
+++ b/packages/@glimmer/application/test/iterable-test.ts
@@ -11,8 +11,8 @@ test('basic iteration of an array of primitives', function(assert) {
       return ['foo', 'bar'];
     },
   };
-  let keyFor = (_, i) => i;
-  let iterable = new Iterable(ref, keyFor);
+  let keyFor = (_: any, i: number) => i;
+  let iterable = new Iterable(ref, keyFor as any);
   let iterator = iterable.iterate();
 
   assert.deepEqual(iterator.next(), {

--- a/packages/@glimmer/test-utils/src/resolvers.ts
+++ b/packages/@glimmer/test-utils/src/resolvers.ts
@@ -1,10 +1,11 @@
 import { Resolver, isSpecifierStringAbsolute } from '@glimmer/di';
 
 export class BlankResolver implements Resolver {
-  identify(specifier: string, referrer?: string) {
+  identify(specifier: string, referrer?: string): string {
     if (isSpecifierStringAbsolute(specifier)) {
       return specifier;
     }
+    throw new Error(`Unexpected non-absolute specifier ${specifier}`);
   }
   retrieve(specifier: string): any {}
 }


### PR DESCRIPTION
Fixes strict mode errors in TypeScript in `@glimmer/application`. This doesn't enable strict mode in `tsconfig.json` yet because some of the other packages have strict mode errors.