### PR TITLE
[BUGFIX] Fixes args tracking in Glimmer component

### DIFF
--- a/packages/@glimmer/component/addon/-private/component-manager.ts
+++ b/packages/@glimmer/component/addon/-private/component-manager.ts
@@ -1,6 +1,5 @@
 import { DEBUG } from '@glimmer/env';
 import Ember from 'ember';
-import { set } from '@ember/object';
 import { getOwner, setOwner } from '@ember/application';
 import ApplicationInstance from '@ember/application/instance';
 import { capabilities } from '@ember/component';
@@ -54,12 +53,12 @@ export default class GlimmerComponentManager {
 
   updateComponent(component: CreateComponentResult, args: ComponentManagerArgs) {
     let argSnapshot = args.named;
-    
+
     if (DEBUG) {
       argSnapshot = Object.freeze(argSnapshot);
     }
-    
-    set(component, 'args', argSnapshot);
+
+    component.args = argSnapshot;
   }
 
   destroyComponent(component: CreateComponentResult) {

--- a/packages/@glimmer/component/addon/-private/component.ts
+++ b/packages/@glimmer/component/addon/-private/component.ts
@@ -184,7 +184,7 @@ export default class GlimmerComponent<T = object> {
    * <p>Welcome, {{@firstName}} {{@lastName}}!</p>
    * ```
    */
-  args: T;
+  args: Readonly<T>;
 
   [DESTROYING] = false;
   [DESTROYED] = false;

--- a/packages/@glimmer/component/addon/-private/component.ts
+++ b/packages/@glimmer/component/addon/-private/component.ts
@@ -1,5 +1,5 @@
 import { DEBUG } from '@glimmer/env';
-import { setOwner, Owner } from './owner';
+import { setOwner } from './owner';
 
 const DESTROYING = Symbol('destroying');
 const DESTROYED = Symbol('destroyed');
@@ -144,8 +144,11 @@ export default class GlimmerComponent<T = object> {
    * @param owner
    * @param args
    */
-  constructor(owner: Owner, args: T) {
-    if (DEBUG && !(owner !== null && typeof owner === 'object' && args[MAGIC_PROP] === true)) {
+  constructor(owner: unknown, args: T) {
+    if (
+      DEBUG &&
+      !(owner !== null && typeof owner === 'object' && (args as any)[MAGIC_PROP] === true)
+    ) {
       throw new Error(
         `You must pass both the owner and args to super() in your component: ${
           this.constructor.name
@@ -154,7 +157,7 @@ export default class GlimmerComponent<T = object> {
     }
 
     this.args = args;
-    setOwner(this, owner);
+    setOwner(this, owner as any);
   }
 
   /**

--- a/packages/@glimmer/component/addon/-private/owner.ts
+++ b/packages/@glimmer/component/addon/-private/owner.ts
@@ -1,1 +1,1 @@
-export { setOwner, Owner } from '@glimmer/di';
+export { setOwner } from '@glimmer/di';

--- a/packages/@glimmer/component/addon/index.ts
+++ b/packages/@glimmer/component/addon/index.ts
@@ -7,7 +7,7 @@ import GlimmerComponentManager from './-private/component-manager';
 import _GlimmerComponent from './-private/component';
 
 class GlimmerComponent<T> extends _GlimmerComponent<T> {
-  get args() {
+  get args(): Readonly<T> {
     return get(this as any, '__args__');
   }
 

--- a/packages/@glimmer/component/addon/index.ts
+++ b/packages/@glimmer/component/addon/index.ts
@@ -1,9 +1,20 @@
 import ApplicationInstance from '@ember/application/instance';
 import { setComponentManager } from '@ember/component';
+import { get, set } from '@ember/object';
 import { gte } from 'ember-compatibility-helpers';
 
 import GlimmerComponentManager from './-private/component-manager';
-import GlimmerComponent from './-private/component';
+import _GlimmerComponent from './-private/component';
+
+class GlimmerComponent<T> extends _GlimmerComponent<T> {
+  get args() {
+    return get(this as any, '__args__');
+  }
+
+  set args(args) {
+    set(this as any, '__args__', args);
+  }
+}
 
 if (gte('3.8.0-beta.1')) {
   setComponentManager((owner: ApplicationInstance) => {

--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -53,7 +53,7 @@
     "@glimmer/interfaces": "^0.39.1",
     "@glimmer/resolver": "^0.3.0",
     "@glimmer/wire-format": "^0.39.1",
-    "@types/ember": "~3.0.26",
+    "@types/ember": "~3.0.29",
     "@types/ember-qunit": "~3.4.3",
     "@types/ember-test-helpers": "~1.0.4",
     "@types/ember-testing-helpers": "^0.0.3",

--- a/packages/@glimmer/component/src/component.ts
+++ b/packages/@glimmer/component/src/component.ts
@@ -40,19 +40,19 @@ export default class Component extends GlimmerComponent<any> {
    * Legacy DOM access and lifecycle hooks. These will be deprecated in favor
    * of render modifiers once Glimmer.js supports an element modifier manager
    * API.
-  */
+   */
 
   /**
    * Called when the component has been inserted into the DOM.
    * Override this function to do any set up that requires an element in the document body.
    */
-  didInsertElement() { }
+  didInsertElement() {}
 
   /**
    * Called when the component has updated and rerendered itself.
    * Called only during a rerender, not during an initial render.
    */
-  didUpdate() { }
+  didUpdate() {}
 
   /**
    * Contains the first and last DOM nodes of a component's rendered template.
@@ -150,7 +150,10 @@ export default class Component extends GlimmerComponent<any> {
    */
   get element(): HTMLElement {
     let { bounds } = this;
-    assert(bounds && bounds.firstNode === bounds.lastNode, `The 'element' property can only be accessed on components that contain a single root element in their template. Try using 'bounds' instead to access the first and last nodes.`);
+    assert(
+      bounds && bounds.firstNode === bounds.lastNode,
+      `The 'element' property can only be accessed on components that contain a single root element in their template. Try using 'bounds' instead to access the first and last nodes.`
+    );
     return bounds.firstNode as HTMLElement;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,9 +753,9 @@
     to-fast-properties "^2.0.0"
 
 "@ember-decorators/babel-transforms@^5.1.3":
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/babel-transforms/-/babel-transforms-5.1.3.tgz#90bc10eb03c513e6fd21c818868a3c44eba55efc"
-  integrity sha512-wllrCE3PB0ic5rcbASXTbfqAP4OhgxeqeutcLScadiZHR+w4fFqYfeAVLm06H7fjOS2D6yqJywSgZE6C2mi/kA==
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/babel-transforms/-/babel-transforms-5.1.4.tgz#e26e0480425e4b6e43be75e24ba85103a02d5459"
+  integrity sha512-uawhQ7fVAaeUgL13aOyvchW77i3Gu1T1lSNf7ZGTRj4SZKIVHPC0HyNTNShd/YIdnTLdBlch0ybCj/2/KJ0mMA==
   dependencies:
     "@babel/plugin-proposal-class-properties" "^7.1.0"
     "@babel/plugin-proposal-decorators" "^7.1.2"
@@ -1085,7 +1085,7 @@
     "@types/jquery" "*"
     "@types/rsvp" "*"
 
-"@types/ember@*", "@types/ember@~3.0.26":
+"@types/ember@*":
   version "3.0.26"
   resolved "https://registry.yarnpkg.com/@types/ember/-/ember-3.0.26.tgz#54381f59c63e8860de9ea0c40defb519f117b0b3"
   integrity sha512-GsvXPrRHBYSq55ZHaXX7NpMvmJBe95Uy8wHAF+2KDIcEy2HbHps6QcnrRBgg/8MEEI71lFs28ZKrTY/YhwyQOw==
@@ -1106,6 +1106,30 @@
     "@types/ember__test" "*"
     "@types/ember__utils" "*"
     "@types/handlebars" "*"
+    "@types/htmlbars-inline-precompile" "*"
+    "@types/jquery" "*"
+    "@types/rsvp" "*"
+
+"@types/ember@~3.0.29":
+  version "3.0.29"
+  resolved "https://registry.yarnpkg.com/@types/ember/-/ember-3.0.29.tgz#a437a60a41f8df9cba52de267bfd0007566eae41"
+  integrity sha512-qW8quUN996GHQlNC4jnQlRcIeZUMW4lL8M16FMAbHEv3cEvY1aPX6GQc4TPt167eR1fAjykfB4cTG6OQFxGHXQ==
+  dependencies:
+    "@types/ember__application" "*"
+    "@types/ember__array" "*"
+    "@types/ember__component" "*"
+    "@types/ember__controller" "*"
+    "@types/ember__debug" "*"
+    "@types/ember__engine" "*"
+    "@types/ember__error" "*"
+    "@types/ember__object" "*"
+    "@types/ember__polyfills" "*"
+    "@types/ember__routing" "*"
+    "@types/ember__runloop" "*"
+    "@types/ember__service" "*"
+    "@types/ember__string" "*"
+    "@types/ember__test" "*"
+    "@types/ember__utils" "*"
     "@types/htmlbars-inline-precompile" "*"
     "@types/jquery" "*"
     "@types/rsvp" "*"


### PR DESCRIPTION
`@tracked` is not yet avalibale for general usage in Ember apps,
so we were relying on using the interop with `get` and
`set` to track args. However, we never actually used `get`,
so it wasn't picking it up. This ensures that all gets/sets of
the field go through the proper codepaths, and will be autotracked.