### PR TITLE
[@glimmer/component] Make component generic over args

### DIFF
--- a/packages/@glimmer/component/src/component.ts
+++ b/packages/@glimmer/component/src/component.ts
@@ -9,7 +9,7 @@ export interface Bounds {
   lastNode: Node;
 }
 
-export default class Component extends GlimmerComponent<any> {
+export default class Component<T extends object = object> extends GlimmerComponent<T> {
   get args() {
     trackedGet(this, 'args');
     return this.__args__;
@@ -25,7 +25,7 @@ export default class Component extends GlimmerComponent<any> {
   /** @private
    * Slot on the component to save Arguments object passed to the `args` setter.
    */
-  private __args__: any;
+  private __args__: T;
 
   /**
    * Development-mode only name of the component, useful for debugging.


### PR DESCRIPTION
This allows TS consumers to (optionally) benefit from formalizing the interface a component has with the outside world.

```ts
import Component from '@glimmer/component';

export default class Foo extends Component<{ word: string}> {

  printWord() {
     console.log(this.args.word); // type-safe access to args
  }
}

```