### PR TITLE
Align yarn and npm install commands

### DIFF
--- a/packages/@glimmer/tracking/README.md
+++ b/packages/@glimmer/tracking/README.md
@@ -8,7 +8,7 @@
 Add this package to your project with Yarn:
 
 ```bash
-yarn add @glimmer/tracking
+yarn add -D @glimmer/tracking
 ```
 
 Or alternatively with npm:


### PR DESCRIPTION
I believe the `yarn add` and `npm install` commands were not equivalent.

The former installed in `dependencies` while the later installed in `devDependencies.`

This changes makes sure both examples are the same and install in `devDependencies.`