### PR TITLE
Handle non-primitive values passed as args in SSR

### DIFF
--- a/packages/@glimmer/ssr/src/application.ts
+++ b/packages/@glimmer/ssr/src/application.ts
@@ -1,7 +1,7 @@
 import { BaseApplication, Loader, Renderer, INTERNAL_DYNAMIC_SCOPE } from '@glimmer/application';
 import { ComponentManager } from '@glimmer/component';
 import { Resolver, Dict } from '@glimmer/di';
-import { PathReference, ConstReference } from '@glimmer/reference';
+import { PathReference, RootReference } from '@glimmer/reference';
 import { DefaultDynamicScope } from '@glimmer/runtime';
 
 import { PassThrough } from 'stream';
@@ -29,7 +29,7 @@ function convertOpaqueToReferenceDict(data: Dict<unknown>): Dict<PathReference<u
   }
 
   return Object.keys(data).reduce((acc, key) => {
-    acc[key] = new ConstReference(data[key]);
+    acc[key] = new RootReference(data[key]);
     return acc;
   }, {});
 }

--- a/packages/@glimmer/ssr/test/node/render-to-string-test.ts
+++ b/packages/@glimmer/ssr/test/node/render-to-string-test.ts
@@ -13,6 +13,16 @@ class RenderToStringTest extends RenderTest {
     assert.equal(html, '<h1>Hello SSR World</h1>');
   }
 
+  @test async 'supports passing non-primitive component args'(assert: Assert) {
+    assert.expect(1);
+    let app = this.app
+      .template('HelloWorld', `<h1>Hello {{@data.name}} World</h1>`);
+
+    const data = { name: 'SSR' };
+    const html = await app.renderToString('HelloWorld', { data });
+    assert.equal(html, '<h1>Hello SSR World</h1>');
+  }
+
   @test async 'renders nested components'(assert: Assert) {
     assert.expect(1);
     let app = this.app


### PR DESCRIPTION
This PR changes `renderToString`/`renderToStream` to use `RootReference` instead of `ConstReference` when wrapping passed component args.

`ConstReference` assumes the wrapped value is a primitive value, and does not implement the `PathReference` interface's `get()` method. Using it here introduced a bug where paths (`{{@foo.bar.baz}}`) do not resolve correctly.