### PR TITLE
Modify SSRApplication.renderToString to accept a custom Serializer

### DIFF
--- a/packages/@glimmer/application-test-helpers/src/app-builder.ts
+++ b/packages/@glimmer/application-test-helpers/src/app-builder.ts
@@ -22,6 +22,8 @@ import { SimpleDocument } from '@simple-dom/interface';
 import { SSRApplication } from '@glimmer/ssr';
 
 import didRender from './did-render';
+import HTMLSerializer from '@simple-dom/serializer';
+import { Renderer } from '@glimmer/application/src/base-application';
 
 export interface AppBuilderOptions<T> {
   appName?: string;
@@ -44,6 +46,15 @@ export interface AppBuilderTemplateMeta {
 
 interface HelperFunction extends Function {
   isFactory?: boolean;
+}
+
+interface TestSSRApplicationOptions {
+  rootName?: string;
+  resolver?: Resolver;
+  loader?: Loader;
+  renderer?: Renderer;
+  serializer?: HTMLSerializer;
+  [INTERNAL_DYNAMIC_SCOPE]?: Dict<unknown>;
 }
 
 function locatorFor(module: string, name: string): TemplateLocator<ModuleLocator> {
@@ -189,7 +200,7 @@ export class AppBuilder<T extends TestApplication> {
     }
   }
 
-  renderToString(componentName: string, data: Dict<unknown>, options?: { [INTERNAL_DYNAMIC_SCOPE]: Dict<unknown> }): Promise<string> {
+  renderToString(componentName: string, data: Dict<unknown>, options?: TestSSRApplicationOptions): Promise<string> {
     const resolver = this.buildResolver();
     let loader = this.buildLoader(resolver);
 

--- a/packages/@glimmer/ssr/src/application.ts
+++ b/packages/@glimmer/ssr/src/application.ts
@@ -17,6 +17,7 @@ export interface SSRApplicationOptions {
   resolver: Resolver;
   loader: Loader;
   renderer: Renderer;
+  serializer?: HTMLSerializer;
   [INTERNAL_DYNAMIC_SCOPE]?: Dict<unknown>;
 }
 
@@ -38,7 +39,7 @@ function convertOpaqueToReferenceDict(data: Dict<unknown>): Dict<PathReference<u
 export default class Application extends BaseApplication {
   protected serializer: HTMLSerializer;
 
-  constructor({ rootName, resolver, loader, renderer }: SSRApplicationOptions) {
+  constructor({ rootName, resolver, loader, renderer, serializer }: SSRApplicationOptions) {
     super({
       rootName,
       resolver,
@@ -47,7 +48,7 @@ export default class Application extends BaseApplication {
       environment: EnvironmentImpl,
     });
 
-    this.serializer = new HTMLSerializer(voidMap);
+    this.serializer = serializer || new HTMLSerializer(voidMap);
     this.registerInitializer({
       initialize(registry) {
         registry.register(

--- a/packages/@glimmer/ssr/test/node/render-to-string-test.ts
+++ b/packages/@glimmer/ssr/test/node/render-to-string-test.ts
@@ -2,6 +2,8 @@ import { test, RenderTest, renderModule } from '@glimmer/application-test-helper
 import Component from '@glimmer/component';
 import { INTERNAL_DYNAMIC_SCOPE } from '@glimmer/application';
 import { getDynamicVar } from '@glimmer/runtime';
+import HTMLSerializer from '@simple-dom/serializer';
+import voidMap from '@simple-dom/void-map';
 
 class RenderToStringTest extends RenderTest {
   @test async 'renders a component'(assert: Assert) {
@@ -82,6 +84,22 @@ class RenderToStringTest extends RenderTest {
       [INTERNAL_DYNAMIC_SCOPE]: {name: 'dynamicScope SSR'}
     });
     assert.equal(html, '<h1>Hello dynamicScope SSR World</h1>');
+  }
+
+  @test async 'renders a component with a custom serializer'(assert: Assert) {
+    class CustomSerializer extends HTMLSerializer {
+      text(text) {
+        return 'MockTest';
+      }
+    }
+    assert.expect(1);
+    let app = this.app
+      .template('HelloWorld', `<h1>Hello World</h1>`);
+
+    const html = await app.renderToString('HelloWorld', {}, {
+      serializer: new CustomSerializer(voidMap),
+    });
+    assert.equal(html, '<h1>MockTest</h1>');
   }
 }
 


### PR DESCRIPTION
- Added it to SSRApplicationOptions
- Modified AppBuilder to have an optional version of SSRApplicationOptions
to keep testing slightly more configurable
- Added tests confirming that a custom serializer can be passed.