### PR TITLE
Ensure the tags Set is properly converted to an Array

### DIFF
--- a/packages/@glimmer/tracking/src/tracked.ts
+++ b/packages/@glimmer/tracking/src/tracked.ts
@@ -25,7 +25,7 @@ class Tracker {
     let { tags } = this;
 
     if (tags.size === 0) return CONSTANT_TAG;
-    return combine([...tags]);
+    return combine(Array.from(tags));
   }
 }
 


### PR DESCRIPTION
Fixes #208 .

TL;DR The original implementation works fine when targeting modern browsers, but when targeting ES5, the resulting array _contains_ the Set rather than being flattened to contain the _items_ in the set.  `Array.from` seems like the safer, more canonical approach here, since the code is attempting to create a new Array from an array-like object such as a Set.