### PR TITLE
Merge pull request #234 from glimmerjs/remove-compiler-from-runtime

### DIFF
--- a/packages/@glimmer/application/package.json
+++ b/packages/@glimmer/application/package.json
@@ -15,7 +15,6 @@
     "dist"
   ],
   "dependencies": {
-    "@glimmer/compiler": "^0.44.0",
     "@glimmer/component": "^1.0.0",
     "@glimmer/di": "^0.1.9",
     "@glimmer/env": "^0.1.7",

--- a/packages/@glimmer/application/src/loaders/runtime-compiler/resolver.ts
+++ b/packages/@glimmer/application/src/loaders/runtime-compiler/resolver.ts
@@ -13,13 +13,16 @@ import {
 } from '@glimmer/interfaces';
 import { Owner } from '@glimmer/di';
 import { expect } from '@glimmer/util';
-import { TemplateFactory, templateFactory } from '@glimmer/opcode-compiler';
-import { PrecompileOptions, precompile } from '@glimmer/compiler';
+import { templateFactory } from '@glimmer/opcode-compiler';
 
 import { TypedRegistry } from './typed-registry';
 import { HelperReference } from '../../helpers/user-helper';
 import { getManager } from '../../components/utils';
-import { CustomComponentDefinition, ManagerDelegate, ComponentFactory } from '../../components/component-managers/custom';
+import {
+  CustomComponentDefinition,
+  ManagerDelegate,
+  ComponentFactory,
+} from '../../components/component-managers/custom';
 import { TemplateOnlyComponentDefinition } from '../../components/component-managers/template-only';
 
 export type UserHelper = (args: ReadonlyArray<unknown>, named: Dict<unknown>) => unknown;
@@ -242,14 +245,4 @@ export function createJitComponentDefinition(
     factory(owner) as ManagerDelegate<unknown>,
     template
   );
-}
-
-export function createTemplate<Locator>(
-  templateSource: string,
-  options?: PrecompileOptions
-): TemplateFactory<Locator> {
-  let wrapper: SerializedTemplateWithLazyBlock<Locator> = JSON.parse(
-    precompile(templateSource, options)
-  );
-  return templateFactory<Locator>(wrapper);
 }


### PR DESCRIPTION
When you pull in `@glimmer/compiler` you will pull in the entire server-side compiler stack causing the runtime to be over 2MB. 

It's unclear why this function was added because it doesn't seem to be used at all. Was introduced here https://github.com/glimmerjs/glimmer.js/pull/170