### PR TITLE
BUGFIX - Prevent duplicate compiled modules in test

### DIFF
--- a/packages/@glimmer/core/src/template.ts
+++ b/packages/@glimmer/core/src/template.ts
@@ -6,15 +6,17 @@ const TEMPLATE_MAP = new WeakMap<object, SerializedTemplateWithLazyBlock<Templat
 const getPrototypeOf = Object.getPrototypeOf;
 
 // This is provided by the `babel-plugin-strict-template-precompile` plugin
-export let createTemplate: ((
+export let createTemplate: (
   scopeOrTemplate: Dict<unknown> | string,
   template?: string
-) => SerializedTemplateWithLazyBlock<TemplateMeta>);
+) => SerializedTemplateWithLazyBlock<TemplateMeta>;
 
 if (DEBUG) {
   createTemplate = (): SerializedTemplateWithLazyBlock<TemplateMeta> => {
-    throw new Error('createTemplate() is meant to be preprocessed with a babel plugin, @glimmer/babel-plugin-strict-template-precompile. If you are seeing this error message, it means that you do not have this babel plugin installed, or it is not enabled correctly');
-  }
+    throw new Error(
+      'createTemplate() is meant to be preprocessed with a babel plugin, @glimmer/babel-plugin-strict-template-precompile. If you are seeing this error message, it means that you do not have this babel plugin installed, or it is not enabled correctly'
+    );
+  };
 }
 
 export function setComponentTemplate<T extends object>(

--- a/packages/@glimmer/core/test/non-interactive/component-template-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/component-template-test.ts
@@ -1,7 +1,6 @@
 const { module, test } = QUnit;
 
-import { setComponentTemplate } from '../..';
-import { getComponentTemplate } from '../../src/template';
+import { getComponentTemplate, setComponentTemplate } from '../../src/template';
 
 module('component templates', () => {
   test('setting and getting', assert => {

--- a/packages/@glimmer/core/test/non-interactive/manager-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/manager-test.ts
@@ -1,7 +1,6 @@
 const { module, test } = QUnit;
 
-import { setComponentManager } from '../..';
-import { getComponentManager } from '../../src/managers';
+import { getComponentManager, setComponentManager } from '../../src/managers';
 
 module('component managers', () => {
   test('setting and getting', assert => {


### PR DESCRIPTION
Locally I did the following:

1. `git checkout master`
2. `git pull --rebase`
3. `git clean -xdf`
4. `yarn build`
5. `yarn test`

Then I had the following test failures:

```bash
not ok 37 Chrome 79.0 - [3 ms] - component templates: setting and getting
    ---
        expected: >
            [object Object]
        stack: >
                at Object.eval (webpack:///./packages/@glimmer/core/test/non-interactive/component-template-test.ts?:34:12)
                at runTest (http://localhost:7357/782893712736681/node_modules/qunit/qunit/qunit.js:3041:30)
                at Test.run (http://localhost:7357/782893712736681/node_modules/qunit/qunit/qunit.js:3027:6)
                at http://localhost:7357/782893712736681/node_modules/qunit/qunit/qunit.js:3258:12
                at processTaskQueue (http://localhost:7357/782893712736681/node_modules/qunit/qunit/qunit.js:2614:24)
                at http://localhost:7357/782893712736681/node_modules/qunit/qunit/qunit.js:2618:8
        message: >
            class A returns explicitly associated template
        negative: >
            false
        browser log: |
    ...
not ok 38 Chrome 79.0 - [2 ms] - component managers: setting and getting
    ---
        expected: >
            [object Object]
        stack: >
                at Object.eval (webpack:///./packages/@glimmer/core/test/non-interactive/manager-test.ts?:35:12)
                at runTest (http://localhost:7357/782893712736681/node_modules/qunit/qunit/qunit.js:3041:30)
                at Test.run (http://localhost:7357/782893712736681/node_modules/qunit/qunit/qunit.js:3027:6)
                at http://localhost:7357/782893712736681/node_modules/qunit/qunit/qunit.js:3258:12
                at processTaskQueue (http://localhost:7357/782893712736681/node_modules/qunit/qunit/qunit.js:2614:24)
                at http://localhost:7357/782893712736681/node_modules/qunit/qunit/qunit.js:2618:8
        message: >
            class A returns explicitly associated manager
        negative: >
            false
        browser log: |
    ...
```

Digging through it more `packages/@glimmer/core/src/template.ts` was being included twice in tests. This meant that the setting into the `Weakmap` was happing in copy of the module and the getter was trying to read it from the `Weakmap` of another copy of the module. 😭 

Unsure how #235 made it through CI.