### PR TITLE
[FEATURE] Adds Owner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,5 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.12
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.16

--- a/packages/@glimmer/component/addon/-private/base-component-manager.ts
+++ b/packages/@glimmer/component/addon/-private/base-component-manager.ts
@@ -1,56 +1,34 @@
 import { DEBUG } from '@glimmer/env';
-import { ComponentManager, CapturedArgs } from '@glimmer/core';
+import { ComponentManager, ComponentCapabilities, CapturedArgs } from '@glimmer/core';
 import BaseComponent, { ARGS_SET } from './component';
-
-export type SetOwner = (obj: {}, owner: unknown) => void;
-export type GetOwner = (obj: {}) => unknown;
-
-export interface CustomComponentCapabilities {
-  asyncLifecycleCallbacks: boolean;
-  destructor: boolean;
-  updateHook: boolean;
-}
 
 export interface Constructor<T> {
   new (owner: unknown, args: {}): T;
 }
 
-/**
- * This factory function returns a component manager class with common behavior
- * that can be extend to add Glimmer.js- or Ember.js-specific functionality. As
- * these environments converge, the need for two component manager
- * implementations (and thus this factory) should go away.
- */
-export default function BaseComponentManager<GlimmerComponent extends BaseComponent>(
-  setOwner: SetOwner,
-  getOwner: GetOwner,
-  capabilities: CustomComponentCapabilities
-): { new(owner: unknown): ComponentManager<GlimmerComponent> } {
-  return class {
-    static create(attrs: {}): ComponentManager<GlimmerComponent> {
-      const owner = getOwner(attrs);
-      return new this(owner);
+export default abstract class BaseComponentManager<GlimmerComponent extends BaseComponent>
+  implements ComponentManager<GlimmerComponent> {
+
+  abstract capabilities: ComponentCapabilities;
+
+  private owner: unknown;
+
+  constructor(owner: unknown) {
+    this.owner = owner;
+  }
+
+  createComponent(
+    ComponentClass: Constructor<GlimmerComponent>,
+    args: CapturedArgs
+  ): GlimmerComponent {
+    if (DEBUG) {
+      ARGS_SET.set(args.named, true);
     }
 
-    capabilities = capabilities;
+    return new ComponentClass(this.owner, args.named);
+  }
 
-    constructor(owner: unknown) {
-      setOwner(this, owner);
-    }
-
-    createComponent(
-      ComponentClass: Constructor<GlimmerComponent>,
-      args: CapturedArgs
-    ): GlimmerComponent {
-      if (DEBUG) {
-        ARGS_SET.set(args.named, true);
-      }
-
-      return new ComponentClass(getOwner(this), args.named);
-    }
-
-    getContext(component: GlimmerComponent): GlimmerComponent {
-      return component;
-    }
-  };
+  getContext(component: GlimmerComponent): GlimmerComponent {
+    return component;
+  }
 }

--- a/packages/@glimmer/component/addon/-private/ember-component-manager.ts
+++ b/packages/@glimmer/component/addon/-private/ember-component-manager.ts
@@ -1,16 +1,13 @@
 import { DEBUG } from '@glimmer/env';
 import Ember from 'ember';
 import { set } from '@ember/object';
-import { getOwner, setOwner } from '@ember/application';
 import { capabilities } from '@ember/component';
 import { schedule } from '@ember/runloop';
 import { gte } from 'ember-compatibility-helpers';
-import BaseComponentManager, {
-  CustomComponentCapabilities,
-} from './base-component-manager';
+import BaseComponentManager from './base-component-manager';
 
 import GlimmerComponent, { setDestroyed, setDestroying } from './component';
-import { CapturedArgs } from '@glimmer/core';
+import { ComponentCapabilities, CapturedArgs } from '@glimmer/core';
 
 const CAPABILITIES = gte('3.13.0-beta.1')
   ? capabilities('3.13', {
@@ -40,7 +37,9 @@ function scheduledDestroyComponent(component: GlimmerComponent, meta: EmberMeta)
  * 1. Properly destroy the component's associated `meta` data structure
  * 2. Schedule destruction using Ember's runloop
  */
-class EmberGlimmerComponentManager extends BaseComponentManager(setOwner, getOwner, CAPABILITIES) {
+class EmberGlimmerComponentManager extends BaseComponentManager<GlimmerComponent> {
+  capabilities = CAPABILITIES;
+
   destroyComponent(component: GlimmerComponent): void {
     if (component.isDestroying) {
       return;
@@ -100,6 +99,6 @@ declare module 'ember' {
 declare module '@ember/component' {
   export function capabilities(
     version: '3.13' | '3.4',
-    capabilities: Partial<CustomComponentCapabilities>
-  ): CustomComponentCapabilities;
+    capabilities: Partial<ComponentCapabilities>
+  ): ComponentCapabilities;
 }

--- a/packages/@glimmer/component/addon/index.ts
+++ b/packages/@glimmer/component/addon/index.ts
@@ -1,21 +1,12 @@
 import { DEBUG } from '@glimmer/env';
 import ApplicationInstance from '@ember/application/instance';
 import { setComponentManager } from '@ember/component';
-import { gte } from 'ember-compatibility-helpers';
 
 import GlimmerComponentManager from './-private/ember-component-manager';
-import GlimmerComponent from './-private/component';
+import _GlimmerComponent from './-private/component';
 import { setOwner } from '@ember/application';
 
-if (gte('3.8.0-beta.1')) {
-  setComponentManager((owner: ApplicationInstance) => {
-    return new GlimmerComponentManager(owner);
-  }, GlimmerComponent);
-} else {
-  setComponentManager('glimmer', GlimmerComponent);
-}
-
-export default class extends GlimmerComponent {
+export default class GlimmerComponent extends _GlimmerComponent {
   constructor(owner, args) {
     super(owner, args);
 
@@ -28,3 +19,7 @@ export default class extends GlimmerComponent {
     setOwner(this, owner);
   }
 }
+
+setComponentManager((owner: ApplicationInstance) => {
+  return new GlimmerComponentManager(owner);
+}, GlimmerComponent);

--- a/packages/@glimmer/component/app/component-managers/glimmer.js
+++ b/packages/@glimmer/component/app/component-managers/glimmer.js
@@ -1,1 +1,0 @@
-export { default } from '@glimmer/component/-private/ember-component-manager';

--- a/packages/@glimmer/component/config/ember-try.js
+++ b/packages/@glimmer/component/config/ember-try.js
@@ -12,10 +12,18 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-3.4',
+          name: 'ember-lts-3.12',
           npm: {
             devDependencies: {
-              'ember-source': '~3.4.0',
+              'ember-source': '~3.12.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.16',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.16.0',
             },
           },
         },

--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -73,7 +73,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^5.0.0",
-    "ember-source": "~3.4.0",
+    "ember-source": "~3.16.0",
     "ember-source-channel-url": "^1.0.1",
     "ember-try": "^1.0.0-beta.3",
     "eslint-plugin-ember": "^5.0.0",

--- a/packages/@glimmer/component/src/component-manager.ts
+++ b/packages/@glimmer/component/src/component-manager.ts
@@ -1,8 +1,6 @@
-import { componentCapabilities, CapturedArgs } from '@glimmer/core';
+import { componentCapabilities } from '@glimmer/core';
 
-import BaseComponentManager, {
-  Constructor,
-} from '../addon/-private/base-component-manager';
+import BaseComponentManager from '../addon/-private/base-component-manager';
 import GlimmerComponent, { setDestroying, setDestroyed } from '../addon/-private/component';
 
 const CAPABILITIES = componentCapabilities('3.13', {
@@ -15,19 +13,8 @@ const CAPABILITIES = componentCapabilities('3.13', {
  * 1. Implement a lightweight destruction protocol (currently not deferred, like in Ember)
  * 2. Invoke legacy component lifecycle hooks (didInsertElement and didUpdate)
  */
-export default class GlimmerComponentManager extends BaseComponentManager(
-  () => null,
-  () => null,
-  CAPABILITIES
-) {
-  createComponent(
-    ComponentClass: Constructor<GlimmerComponent>,
-    args: CapturedArgs
-  ): GlimmerComponent {
-    const instance = super.createComponent(ComponentClass, args);
-
-    return instance;
-  }
+export default class GlimmerComponentManager extends BaseComponentManager<GlimmerComponent> {
+  capabilities = CAPABILITIES;
 
   destroyComponent(component: GlimmerComponent): void {
     setDestroying(component);

--- a/packages/@glimmer/component/src/component.ts
+++ b/packages/@glimmer/component/src/component.ts
@@ -1,8 +1,21 @@
-import { setComponentManager } from '@glimmer/core';
+import { setComponentManager, setOwner } from '@glimmer/core';
 import GlimmerComponentManager from './component-manager';
-import GlimmerComponent from '../addon/-private/component';
+import _GlimmerComponent from '../addon/-private/component';
+import { DEBUG } from '@glimmer/env';
 
-export default GlimmerComponent;
+export default class GlimmerComponent<Args extends {} = {}> extends _GlimmerComponent<Args> {
+  constructor(owner: unknown, args: Args) {
+    super(owner, args);
+
+    if (DEBUG && !(owner !== null && typeof owner === 'object')) {
+      throw new Error(
+        `You must pass both the owner and args to super() in your component: ${this.constructor.name}. You can pass them directly, or use ...arguments to pass all arguments through.`
+      );
+    }
+
+    setOwner(this, owner);
+  }
+}
 
 setComponentManager((owner: {}) => {
   return new GlimmerComponentManager(owner);

--- a/packages/@glimmer/core/index.ts
+++ b/packages/@glimmer/core/index.ts
@@ -20,3 +20,5 @@ export {
 export { templateOnlyComponent } from './src/managers/component/template-only';
 
 export { createTemplate, setComponentTemplate } from './src/template';
+
+export { getOwner, setOwner } from './src/owner';

--- a/packages/@glimmer/core/src/managers/component/template-only.ts
+++ b/packages/@glimmer/core/src/managers/component/template-only.ts
@@ -14,7 +14,7 @@ import { CONSTANT_TAG, Tag } from '@glimmer/validator';
 import { DEBUG } from '@glimmer/env';
 
 import { unwrapTemplate } from '@glimmer/opcode-compiler';
-import { TemplateMeta } from './custom';
+import { TemplateMeta } from '../../template';
 
 export const CAPABILITIES: ComponentCapabilities = {
   attributeHook: false,

--- a/packages/@glimmer/core/src/managers/modifier.ts
+++ b/packages/@glimmer/core/src/managers/modifier.ts
@@ -37,3 +37,5 @@ export interface ModifierManager<ModifierInstance> {
   updateModifier(instance: ModifierInstance, args: Args): void;
   destroyModifier(instance: ModifierInstance, args: Args): void;
 }
+
+export type ModifierDefinition<_Instance = unknown> = {};

--- a/packages/@glimmer/core/src/owner.ts
+++ b/packages/@glimmer/core/src/owner.ts
@@ -1,0 +1,27 @@
+import { DEBUG } from '@glimmer/env';
+
+const OWNER_MAP = new WeakMap<{}, unknown>();
+
+export const OWNER_KEY = `__OWNER_${Math.floor(Math.random() * Date.now())}__`;
+
+export let DEFAULT_OWNER = {};
+
+if (DEBUG) {
+  const OWNER_ERROR = 'You attempted to use the Owner for a component, modifier, or helper, but did not provide an owner to `renderComponent`.';
+  DEFAULT_OWNER = new Proxy(DEFAULT_OWNER, {
+    get(): never {
+      throw new Error(OWNER_ERROR);
+    },
+    set(): never {
+      throw new Error(OWNER_ERROR);
+    }
+  });
+}
+
+export function getOwner<T = unknown>(obj: object): T {
+  return OWNER_MAP.get(obj) as T;
+}
+
+export function setOwner(obj: object, owner: unknown): void {
+  OWNER_MAP.set(obj, owner);
+}

--- a/packages/@glimmer/core/src/render-component/resolvers.ts
+++ b/packages/@glimmer/core/src/render-component/resolvers.ts
@@ -16,7 +16,8 @@ import {
   vmHandleForModifier,
 } from './vm-definitions';
 
-import { ComponentDefinition, TemplateMeta } from '../managers/component/custom';
+import { ComponentDefinition } from '../managers/component/custom';
+import { TemplateMeta } from '../template';
 
 ///////////
 

--- a/packages/@glimmer/core/src/template.ts
+++ b/packages/@glimmer/core/src/template.ts
@@ -1,6 +1,9 @@
 import { DEBUG } from '@glimmer/env';
 import { SerializedTemplateWithLazyBlock, Dict } from '@glimmer/interfaces';
-import { TemplateMeta } from './managers/component/custom';
+
+export interface TemplateMeta {
+  scope: () => Dict<unknown>;
+}
 
 const TEMPLATE_MAP = new WeakMap<object, SerializedTemplateWithLazyBlock<TemplateMeta>>();
 const getPrototypeOf = Object.getPrototypeOf;

--- a/packages/@glimmer/core/test/non-interactive/render-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/render-test.ts
@@ -8,6 +8,7 @@ import {
   setComponentTemplate,
   createTemplate,
   templateOnlyComponent,
+  getOwner,
 } from '@glimmer/core';
 
 import { module, test, render } from '../utils';
@@ -165,28 +166,33 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
   //   assert.equal(await render(MainComponent), 'Hello Glimmer!');
   // });
 
-  // test('a component can inject services', async assert => {
-  //   class LocaleService {
-  //     get currentLocale(): string {
-  //       return 'en_US';
-  //     }
-  //   }
+  test('components receive owner', async assert => {
+    class Owner {
+      services = {
+        locale: new LocaleService(),
+      };
+    }
 
-  //   class MyComponent extends Component {
-  //     get myLocale(): string {
-  //       return (getHostMeta(this) as { locale: LocaleService })!.locale.currentLocale;
-  //     }
-  //   }
+    class LocaleService {
+      get currentLocale(): string {
+        return 'en_US';
+      }
+    }
 
-  //   setComponentTemplate(MyComponent, createTemplate('<h1>{{this.myLocale}}</h1>'));
+    class MyComponent extends Component {
+      get myLocale(): string {
+        return getOwner<Owner>(this).services.locale.currentLocale;
+      }
+    }
 
-  //   const html = await render(MyComponent, {
-  //     meta: {
-  //       locale: new LocaleService(),
-  //     },
-  //   });
-  //   assert.strictEqual(html, '<h1>en_US</h1>');
-  // });
+    setComponentTemplate(MyComponent, createTemplate('<h1>{{this.myLocale}}</h1>'));
+
+    const html = await render(MyComponent, {
+      owner: new Owner(),
+    });
+
+    assert.strictEqual(html, '<h1>en_US</h1>');
+  });
 
   // test('a helper can inject services', async assert => {
   //   class LocaleService {

--- a/packages/@glimmer/core/test/utils.ts
+++ b/packages/@glimmer/core/test/utils.ts
@@ -8,7 +8,7 @@ import {
 } from '..';
 import { renderToString } from '@glimmer/ssr';
 import { SerializedTemplateWithLazyBlock } from '@glimmer/interfaces';
-import { TemplateMeta } from '../src/managers/component/custom';
+import { TemplateMeta } from '../src/template';
 
 export const module = QUnit.module;
 export const test = QUnit.test;

--- a/packages/@glimmer/ssr/src/render.ts
+++ b/packages/@glimmer/ssr/src/render.ts
@@ -28,6 +28,7 @@ class ServerEnvDelegate extends BaseEnvDelegate {
 export interface RenderOptions {
   args?: Dict<unknown>;
   serializer?: HTMLSerializer;
+  owner?: object
 }
 
 const defaultSerializer = new HTMLSerializer(voidMap);
@@ -65,7 +66,8 @@ export function renderToStream(
     element,
     { appendOperations, updateOperations },
     new ServerEnvDelegate(),
-    options.args
+    options.args,
+    options.owner
   );
   iterator.sync();
 

--- a/packages/example-apps/basic/index.ts
+++ b/packages/example-apps/basic/index.ts
@@ -1,5 +1,12 @@
 import { renderComponent } from '@glimmer/core';
 import MyComponent from './src/MyComponent';
+import LocaleService from './src/services/LocaleService';
+
+export interface Owner {
+  services: {
+    locale: LocaleService;
+  };
+}
 
 document.addEventListener(
   'DOMContentLoaded',
@@ -7,6 +14,12 @@ document.addEventListener(
     const element = document.getElementById('app');
     renderComponent(MyComponent, {
       element: element!,
+
+      owner: {
+        services: {
+          locale: new LocaleService('en_US'),
+        },
+      },
     });
   },
   { once: true }

--- a/packages/example-apps/basic/src/MyComponent.ts
+++ b/packages/example-apps/basic/src/MyComponent.ts
@@ -4,10 +4,12 @@ import {
   createTemplate,
   setComponentTemplate,
   templateOnlyComponent,
+  getOwner,
 } from '@glimmer/core';
 import { helper } from '@glimmer/helper';
 import OtherComponent from './OtherComponent';
 import { on, action } from '@glimmer/modifier';
+import { Owner } from '..';
 
 const myHelper = helper(function([name], { greeting }) {
   return `Helper: ${greeting} ${name}`;
@@ -36,8 +38,7 @@ class MyComponent extends Component {
   @tracked count = 55;
 
   get currentLocale(): string {
-    return 'zh_CN';
-    // return (getHostMeta(this) as { locale: LocaleService }).locale.currentLocale;
+    return getOwner<Owner>(this).services.locale.currentLocale;
   }
 
   @action

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,6 +67,16 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
+"@babel/generator@^7.8.6":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.7.tgz#870b3cf7984f5297998152af625c4f3e341400f7"
+  integrity sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==
+  dependencies:
+    "@babel/types" "^7.8.7"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz#60bc0bc657f63a0924ff9a4b4a0b24a13cf4deee"
@@ -303,6 +313,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/parser@^7.4.5", "@babel/parser@^7.8.6":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.7.tgz#7b8facf95d25fef9534aad51c4ffecde1a61e26a"
+  integrity sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==
+
 "@babel/parser@^7.8.3", "@babel/parser@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.4.tgz#d1dbe64691d60358a974295fa53da074dd2ce8e8"
@@ -483,7 +498,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-block-scoping@^7.8.3":
+"@babel/plugin-transform-block-scoping@^7.6.2", "@babel/plugin-transform-block-scoping@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz#97d35dab66857a437c166358b91d09050c868f3a"
   integrity sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==
@@ -619,6 +634,13 @@
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz#60cc2ae66d85c95ab540eb34babb6434d4c70c43"
   integrity sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-transform-object-assign@^7.2.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.8.3.tgz#dc3b8dd50ef03837868a37b7df791f64f288538e"
+  integrity sha512-i3LuN8tPDqUCRFu3dkzF2r1Nx0jp4scxtm7JxtIqI9he9Vk20YD+/zshdzR9JLsoBMlJlNR82a62vQExNEVx/Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
@@ -854,6 +876,21 @@
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+"@babel/traverse@^7.4.5":
+  version "7.8.6"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.6.tgz#acfe0c64e1cd991b3e32eae813a6eb564954b5ff"
+  integrity sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.6"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.8.6"
+    "@babel/types" "^7.8.6"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.4.tgz#f0845822365f9d5b0e312ed3959d3f827f869e3c"
@@ -878,6 +915,15 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.4.0", "@babel/types@^7.8.6", "@babel/types@^7.8.7":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.7.tgz#1fc9729e1acbb2337d5b6977a63979b4819f5d1d"
+  integrity sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
 "@babel/types@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
@@ -886,6 +932,11 @@
     esutils "^2.0.2"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
+
+"@ember/edition-utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ember/edition-utils/-/edition-utils-1.2.0.tgz#a039f542dc14c8e8299c81cd5abba95e2459cfa6"
+  integrity sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==
 
 "@ember/optional-features@^0.6.1":
   version "0.6.4"
@@ -2951,10 +3002,10 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-ast-types@0.9.6:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
-  integrity sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=
+ast-types@0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.2.tgz#df39b677a911a83f3a049644fb74fdded23cea48"
+  integrity sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -3260,6 +3311,14 @@ babel-plugin-ember-modules-api-polyfill@^2.12.0, babel-plugin-ember-modules-api-
   integrity sha512-ZQU4quX0TJ1yYyosPy5PFigKdCFEVHJ6H0b3hwjxekIP9CDwzk0OhQuKhCOPti+d52VWjjCjxu2BrXEih29mFw==
   dependencies:
     ember-rfc176-data "^0.3.12"
+
+babel-plugin-filter-imports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-3.0.0.tgz#a849683837ad29960da17492fb32789ab6b09a11"
+  integrity sha512-p/chjzVTgCxUqyLM0q/pfWVZS7IJTwGQMwNg0LOvuQpKiTftQgZDtkGB8XvETnUw19rRcL7bJCTopSwibTN2tA==
+  dependencies:
+    "@babel/types" "^7.4.0"
+    lodash "^4.17.11"
 
 babel-plugin-htmlbars-inline-precompile@^0.2.5:
   version "0.2.6"
@@ -3966,7 +4025,7 @@ broccoli-clean-css@^1.1.0:
     inline-source-map-comment "^1.0.5"
     json-stable-stringify "^1.0.0"
 
-broccoli-concat@^3.5.1:
+broccoli-concat@^3.5.1, broccoli-concat@^3.7.4:
   version "3.7.5"
   resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-3.7.5.tgz#223beda8c1184252cf08ae020a3d45ffa6a48218"
   integrity sha512-rDs1Mej3Ej0Cy5yIO9oIQq5+BCv0opAwS2NW7M0BeCsAMeFM42Z/zacDUC6jKc5OV5wiHvGTyCPLnZkMe0h6kQ==
@@ -6081,13 +6140,6 @@ ember-cli-uglify@^2.1.0:
     broccoli-uglify-sourcemap "^2.1.1"
     lodash.defaultsdeep "^4.6.0"
 
-ember-cli-valid-component-name@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-valid-component-name/-/ember-cli-valid-component-name-1.0.0.tgz#71550ce387e0233065f30b30b1510aa2dfbe87ef"
-  integrity sha1-cVUM44fgIzBl8wswsVEKot++h+8=
-  dependencies:
-    silent-error "^1.0.0"
-
 ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.1, ember-cli-version-checker@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
@@ -6273,12 +6325,14 @@ ember-rfc176-data@^0.3.12, ember-rfc176-data@^0.3.5:
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.12.tgz#90d82878e69e2ac9a5438e8ce14d12c6031c5bd2"
   integrity sha512-g9HeZj/gU5bfIIrGXkP7MhS2b3Vu5DfNUrYr14hy99TgIvtZETO+96QF4WOEUXGjIJdfTRjerVnQlqngPQSv1g==
 
-ember-router-generator@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/ember-router-generator/-/ember-router-generator-1.2.3.tgz#8ed2ca86ff323363120fc14278191e9e8f1315ee"
-  integrity sha1-jtLKhv8yM2MSD8FCeBkeno8TFe4=
+ember-router-generator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-router-generator/-/ember-router-generator-2.0.0.tgz#d04abfed4ba8b42d166477bbce47fccc672dbde0"
+  integrity sha512-89oVHVJwmLDvGvAUWgS87KpBoRhy3aZ6U0Ql6HOmU4TrPkyaa8pM0W81wj9cIwjYprcQtN9EwzZMHnq46+oUyw==
   dependencies:
-    recast "^0.11.3"
+    "@babel/parser" "^7.4.5"
+    "@babel/traverse" "^7.4.5"
+    recast "^0.18.1"
 
 ember-source-channel-url@^1.0.1:
   version "1.2.0"
@@ -6287,25 +6341,35 @@ ember-source-channel-url@^1.0.1:
   dependencies:
     got "^8.0.1"
 
-ember-source@~3.4.0:
-  version "3.4.8"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.4.8.tgz#68677bf9bd222aff865100b241004649c3d3dda7"
-  integrity sha512-uiRqAzzFKvZ0P5zf5eOv2BrhBUNFJOnsUrri6dN8Ci7pxBkj/fyKVxwIu/+juQh4E/QRgrfze/+Cueq0FNf6rQ==
+ember-source@~3.16.0:
+  version "3.16.3"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.16.3.tgz#080ded36d6b43ed1ee8e9a13ed4cebf27a50db6a"
+  integrity sha512-A5IuTBDnxM4zK5IOaoePOchmgaKm4iYuYfQZVsvuPoczm89SBTKuQZnsXFp2ZI8Sc17ALm1Euc9Lc10TNy2KXw==
   dependencies:
-    broccoli-funnel "^2.0.1"
-    broccoli-merge-trees "^2.0.0"
-    chalk "^2.3.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/plugin-transform-block-scoping" "^7.6.2"
+    "@babel/plugin-transform-object-assign" "^7.2.0"
+    "@ember/edition-utils" "^1.2.0"
+    babel-plugin-debug-macros "^0.3.3"
+    babel-plugin-filter-imports "^3.0.0"
+    broccoli-concat "^3.7.4"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.2"
+    broccoli-merge-trees "^3.0.2"
+    chalk "^2.4.2"
+    ember-cli-babel "^7.11.0"
     ember-cli-get-component-path-option "^1.0.0"
     ember-cli-is-package-missing "^1.0.0"
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-path-utils "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-valid-component-name "^1.0.0"
-    ember-cli-version-checker "^2.1.0"
-    ember-router-generator "^1.2.3"
+    ember-cli-version-checker "^3.1.3"
+    ember-router-generator "^2.0.0"
     inflection "^1.12.0"
-    jquery "^3.3.1"
-    resolve "^1.6.0"
+    jquery "^3.4.1"
+    resolve "^1.11.1"
+    semver "^6.1.1"
+    silent-error "^1.1.1"
 
 ember-test-waiters@^1.1.1:
   version "1.2.0"
@@ -6662,7 +6726,7 @@ espree@^6.1.2:
     acorn-jsx "^5.1.0"
     eslint-visitor-keys "^1.1.0"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -6671,11 +6735,6 @@ esprima@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.0.0.tgz#53cf247acda77313e551c3aa2e73342d3fb4f7d9"
   integrity sha1-U88kes2ncxPlUcOqLnM0LT+099k=
-
-esprima@~3.1.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
-  integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
 esquery@^1.0.1:
   version "1.0.1"
@@ -8840,7 +8899,7 @@ jquery-deferred@^0.3.0:
   resolved "https://registry.yarnpkg.com/jquery-deferred/-/jquery-deferred-0.3.1.tgz#596eca1caaff54f61b110962b23cafea74c35355"
   integrity sha1-WW7KHKr/VPYbEQlisjyv6nTDU1U=
 
-jquery@^3.3.1:
+jquery@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
@@ -11032,7 +11091,7 @@ printf@^0.5.1:
   resolved "https://registry.yarnpkg.com/printf/-/printf-0.5.2.tgz#8546e01a1f647b1dff510ae92bdc92beb8c9b2f9"
   integrity sha512-Hn0UuWqTRd94HiCJoiCNGZTnSyXJdIF3t4/4I293hezIzyH4pQ3ai4TlH/SmRCiMvR5aNMxSYWshjQWWW6J8MQ==
 
-private@^0.1.6, private@^0.1.8, private@~0.1.5:
+private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
@@ -11444,15 +11503,15 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-recast@^0.11.3:
-  version "0.11.23"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
-  integrity sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=
+recast@^0.18.1:
+  version "0.18.7"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.18.7.tgz#56338a6d803c8c3b9113344440dc70d13c8a1ef7"
+  integrity sha512-qNfoxvMkW4k8jJgNCfmIES7S31MEejXcEQs57eKUcQGiJUuX7cXNOD2h+W9z0rjNun2EkKqf0WvuRtmHw4NPNg==
   dependencies:
-    ast-types "0.9.6"
-    esprima "~3.1.0"
-    private "~0.1.5"
-    source-map "~0.5.0"
+    ast-types "0.13.2"
+    esprima "~4.0.0"
+    private "^0.1.8"
+    source-map "~0.6.1"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -11737,7 +11796,7 @@ resolve@1.9.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
   integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
@@ -11971,7 +12030,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -12102,7 +12161,7 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0:
+silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0, silent-error@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/silent-error/-/silent-error-1.1.1.tgz#f72af5b0d73682a2ba1778b7e32cd8aa7c2d8662"
   integrity sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==
@@ -12368,7 +12427,7 @@ source-map@0.4.x, source-map@^0.4.2:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=


### PR DESCRIPTION
Adds a `owner` argument that can be passed to `renderComponent`. This
value is provided to every manager in that render tree via the manager
factory:

```js
setComponentManager((owner) => new CustomManager(owner), {});
```

Conceptually, the owner here is similar to the owner in Ember.js.
Glimmer.js creates a new manager for each unique owner that it receives,
and managers can use the `getOwner` and `setOwner` methods to assign it
to passed objects. The owner is an opaque value, so it's up to the
embedding environment to decide what its API is. If no owner is passed,
a default owner is used, and throws an error if the user attempts to use
it for anything.

---

Breaking changes:

* Removes support for Ember prior to 3.8, which used a (now deprecated) version of component manager association that relied on Ember's resolver.