### PR TITLE
[CLEANUP] Updates ComponentFactory to ComponentDefinition

### DIFF
--- a/packages/@glimmer/blueprint/files/tests/util.ts
+++ b/packages/@glimmer/blueprint/files/tests/util.ts
@@ -1,6 +1,6 @@
 import {
   renderComponent as glimmerRenderComponent,
-  ComponentFactory,
+  ComponentDefinition,
   RenderComponentOptions,
   didRender,
 } from '@glimmer/core';
@@ -22,7 +22,7 @@ Object.defineProperty(QUnit.assert.dom, 'rootElement', { get: getTestRoot });
 // can still override the element by passing it directly, in cases where that
 // is necessary.
 export async function renderComponent(
-  component: ComponentFactory,
+  component: ComponentDefinition,
   elementOrOptions: HTMLElement | Partial<RenderComponentOptions> = {}
 ): Promise<void> {
   let options: RenderComponentOptions;

--- a/packages/@glimmer/core/index.ts
+++ b/packages/@glimmer/core/index.ts
@@ -12,7 +12,7 @@ export { setComponentManager, setModifierManager } from './src/managers';
 export {
   Args as CapturedArgs,
   ComponentManager,
-  ComponentFactory,
+  ComponentDefinition,
   capabilities as componentCapabilities,
   Capabilities as ComponentCapabilities,
 } from './src/managers/component/custom';

--- a/packages/@glimmer/core/src/managers/component/custom.ts
+++ b/packages/@glimmer/core/src/managers/component/custom.ts
@@ -76,7 +76,7 @@ export interface Args {
  */
 export interface ComponentManager<ComponentInstance> {
   capabilities: Capabilities;
-  createComponent(factory: unknown, args: Args): ComponentInstance;
+  createComponent(definition: unknown, args: Args): ComponentInstance;
   getContext(instance: ComponentInstance): unknown;
 }
 
@@ -136,13 +136,6 @@ export interface TemplateMeta {
 
 export interface Destroyable {
   destroy(): void;
-}
-
-export interface Factory<T, C extends object = object> {
-  class?: C;
-  fullName?: string;
-  normalizedName?: string;
-  create(props?: { [prop: string]: unknown }): T;
 }
 
 ///////////
@@ -343,7 +336,7 @@ export class CustomComponentState<ComponentInstance> {
 
 export interface CustomComponentDefinitionState<ComponentInstance> {
   delegate: ComponentManager<ComponentInstance>;
-  ComponentClass: ComponentFactory;
+  ComponentClass: ComponentDefinition;
   definition: CustomComponentDefinition<ComponentInstance>;
 }
 
@@ -357,7 +350,7 @@ export class CustomComponentDefinition<ComponentInstance> {
 
   constructor(
     handle: number,
-    ComponentClass: ComponentFactory,
+    ComponentClass: ComponentDefinition,
     delegate: ComponentManager<ComponentInstance>,
     template: Template<TemplateMeta>
   ) {
@@ -372,4 +365,4 @@ export class CustomComponentDefinition<ComponentInstance> {
   }
 }
 
-export type ComponentFactory = {}
+export type ComponentDefinition = {}

--- a/packages/@glimmer/core/src/managers/index.ts
+++ b/packages/@glimmer/core/src/managers/index.ts
@@ -71,8 +71,8 @@ function getManagerInstanceForOwner<D extends ManagerDelegate>(
 
 ///////////
 
-export function setModifierManager(factory: ManagerFactory<ModifierManager<unknown>>, obj: {}): {} {
-  return setManager({ factory, type: 'modifier' }, obj);
+export function setModifierManager(factory: ManagerFactory<ModifierManager<unknown>>, definition: {}): {} {
+  return setManager({ factory, type: 'modifier' }, definition);
 }
 
 export function getModifierManager(owner: object, obj: {}): ModifierManager<unknown> | undefined {
@@ -83,8 +83,8 @@ export function getModifierManager(owner: object, obj: {}): ModifierManager<unkn
   }
 }
 
-export function setComponentManager(factory: ManagerFactory<ComponentManager<unknown>>, obj: {}): {} {
-  return setManager({ factory, type: 'component' }, obj);
+export function setComponentManager(factory: ManagerFactory<ComponentManager<unknown>>, definition: {}): {} {
+  return setManager({ factory, type: 'component' }, definition);
 }
 
 export function getComponentManager(

--- a/packages/@glimmer/core/src/managers/modifier.ts
+++ b/packages/@glimmer/core/src/managers/modifier.ts
@@ -32,7 +32,7 @@ export interface Args {
 
 export interface ModifierManager<ModifierInstance> {
   capabilities: Capabilities;
-  createModifier(factory: unknown, args: Args): ModifierInstance;
+  createModifier(definition: unknown, args: Args): ModifierInstance;
   installModifier(instance: ModifierInstance, element: SimpleElement, args: Args): void;
   updateModifier(instance: ModifierInstance, args: Args): void;
   destroyModifier(instance: ModifierInstance, args: Args): void;

--- a/packages/@glimmer/core/src/render-component/index.ts
+++ b/packages/@glimmer/core/src/render-component/index.ts
@@ -19,7 +19,7 @@ import { ClientEnvDelegate } from '../environment/delegates';
 import { CompileTimeResolver, RuntimeResolver } from './resolvers';
 
 import { ComponentRootReference, PathReference } from '@glimmer/reference';
-import { ComponentFactory } from '../managers/component/custom';
+import { ComponentDefinition } from '../managers/component/custom';
 
 import { SimpleElement, SimpleDocument } from '@simple-dom/interface';
 import { RuntimeProgramImpl } from '@glimmer/program';
@@ -45,15 +45,15 @@ export function didRender(): Promise<void> {
 }
 
 async function renderComponent(
-  ComponentClass: ComponentFactory,
+  ComponentClass: ComponentDefinition,
   options: RenderComponentOptions
 ): Promise<void>;
 async function renderComponent(
-  ComponentClass: ComponentFactory,
+  ComponentClass: ComponentDefinition,
   element: HTMLElement
 ): Promise<void>;
 async function renderComponent(
-  ComponentClass: ComponentFactory,
+  ComponentClass: ComponentDefinition,
   optionsOrElement: RenderComponentOptions | HTMLElement
 ): Promise<void> {
   const options: RenderComponentOptions =
@@ -120,7 +120,7 @@ function dictToReference(dict: Dict<unknown>, env: Environment): Dict<PathRefere
 }
 
 export function getTemplateIterator(
-  ComponentClass: ComponentFactory,
+  ComponentClass: ComponentDefinition,
   element: Element | SimpleElement,
   envOptions: EnvironmentOptions,
   envDelegate: EnvironmentDelegate,

--- a/packages/@glimmer/core/test/utils.ts
+++ b/packages/@glimmer/core/test/utils.ts
@@ -1,6 +1,6 @@
 import {
   renderComponent,
-  ComponentFactory,
+  ComponentDefinition,
   RenderComponentOptions,
   didRender,
   templateOnlyComponent,
@@ -16,7 +16,7 @@ export const test = QUnit.test;
 const IS_INTERACTIVE = typeof document !== 'undefined';
 
 export async function render(
-  component: ComponentFactory | SerializedTemplateWithLazyBlock<TemplateMeta>,
+  component: ComponentDefinition | SerializedTemplateWithLazyBlock<TemplateMeta>,
   options?: HTMLElement | Partial<RenderComponentOptions>
 ): Promise<string> {
   if ('id' in component && 'block' in component && 'meta' in component) {

--- a/packages/@glimmer/ssr/src/render.ts
+++ b/packages/@glimmer/ssr/src/render.ts
@@ -1,4 +1,4 @@
-import { ComponentFactory, getTemplateIterator } from '@glimmer/core';
+import { ComponentDefinition, getTemplateIterator } from '@glimmer/core';
 import { Dict } from '@glimmer/interfaces';
 import createHTMLDocument from '@simple-dom/document';
 import HTMLSerializer from '@simple-dom/serializer';
@@ -33,7 +33,7 @@ export interface RenderOptions {
 const defaultSerializer = new HTMLSerializer(voidMap);
 
 export function renderToString(
-  ComponentClass: ComponentFactory,
+  ComponentClass: ComponentDefinition,
   options?: RenderOptions
 ): Promise<string> {
   return new Promise<string>((resolve, reject) => {
@@ -50,7 +50,7 @@ export function renderToString(
 
 export function renderToStream(
   stream: NodeJS.WritableStream,
-  ComponentClass: ComponentFactory,
+  ComponentClass: ComponentDefinition,
   options: RenderOptions = {}
 ): void {
   const document = createHTMLDocument();


### PR DESCRIPTION
As I began the work on adding `ModifierManager` and `HelperManager`, it
became more clear that "factory" wasn't really the right term for the
values provided to `setComponentManager`, etc. We aren't assigning a
factory, we're assigning a _definition_ that could be a factory.

The only reason this would be an issue is it somewhat conflicts with the
terminology used internally by the VM. This PR makes the distinction
more clear, and renames "factory" to "definition" for the external
types in general.