### PR TITLE
[BUGFIX] Ensures Strict Mode

### DIFF
--- a/packages/@glimmer/core/src/render-component/resolvers.ts
+++ b/packages/@glimmer/core/src/render-component/resolvers.ts
@@ -21,6 +21,7 @@ import { ComponentDefinition } from '../managers/component/custom';
 import { TemplateMeta } from '../template';
 import { HelperDefinition } from '../managers/helper';
 import { ifHelper } from './built-ins';
+import { DEBUG } from '@glimmer/env';
 
 const builtInHelpers: { [key: string]: VMHelperDefinition } = {
   if: vmDefinitionForBuiltInHelper(ifHelper),
@@ -93,10 +94,6 @@ export class CompileTimeResolver implements ResolverDelegate {
     const scope = referrer.scope();
     const modifier = scope[name] as Modifier;
 
-    if (modifier === undefined) {
-      throw new Error(`Cannot find modifier ${name} in scope`);
-    }
-
     const handle = vmHandleForModifier(modifier);
     this.inner.registry[handle] = modifier;
     return handle;
@@ -106,8 +103,8 @@ export class CompileTimeResolver implements ResolverDelegate {
     const scope = referrer.scope();
     const ComponentDefinition = scope[name] as ComponentDefinition;
 
-    if (ComponentDefinition === undefined) {
-      throw new Error(`Cannot find component ${name} in scope`);
+    if (DEBUG && ComponentDefinition === undefined) {
+      throw new Error(`Cannot find component \`${name}\` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add \`this\` to it: \`<this.${name}>\``);
     }
 
     const definition = vmDefinitionForComponent(ComponentDefinition);

--- a/packages/@glimmer/core/src/template.ts
+++ b/packages/@glimmer/core/src/template.ts
@@ -22,10 +22,28 @@ if (DEBUG) {
   };
 }
 
+const builtInHelpers = {
+  if: true,
+  each: true,
+};
+
 export function setComponentTemplate<T extends object>(
   ComponentClass: T,
   template: SerializedTemplateWithLazyBlock<TemplateMeta>
 ): T {
+  if (DEBUG) {
+    const scope = template.meta.scope();
+    const block = JSON.parse(template.block);
+
+    if (block.upvars) {
+      for (const upvar of block.upvars) {
+        if (!(upvar in builtInHelpers) && scope[upvar] === undefined) {
+          throw new Error(`Cannot find identifier \`${upvar}\` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add \`this\` to it: \`{{this.${upvar}}}\``);
+        }
+      }
+    }
+  }
+
   TEMPLATE_MAP.set(ComponentClass, template);
   return ComponentClass;
 }

--- a/packages/@glimmer/core/test/interactive/fn-test.ts
+++ b/packages/@glimmer/core/test/interactive/fn-test.ts
@@ -35,7 +35,7 @@ module('[@glimmer/core] interactive - {{fn}}', () => {
       HelloWorld,
       createTemplate(
         { on, fn },
-        '<button {{on "click" (fn this.userDidClick "hello" name)}}>Hello World</button>'
+        '<button {{on "click" (fn this.userDidClick "hello" this.name)}}>Hello World</button>'
       )
     );
 

--- a/packages/@glimmer/core/test/non-interactive/component-template-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/component-template-test.ts
@@ -1,11 +1,19 @@
 const { module, test } = QUnit;
 
-import { getComponentTemplate, setComponentTemplate } from '../../src/template';
+import { getComponentTemplate, setComponentTemplate, TemplateMeta } from '../../src/template';
+import { SerializedTemplateWithLazyBlock } from '@glimmer/interfaces';
+
+class FakeTemplateMeta implements SerializedTemplateWithLazyBlock<TemplateMeta> {
+  block = "{}";
+  meta = {
+    scope: (): {} => ({})
+  }
+}
 
 module('component templates', () => {
   test('setting and getting', assert => {
-    const templateA = {} as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-    const templateAAB = {} as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    const templateA = new FakeTemplateMeta();
+    const templateAAB = new FakeTemplateMeta();
 
     class A {}
     setComponentTemplate(A, templateA);

--- a/packages/@glimmer/core/test/non-interactive/index.ts
+++ b/packages/@glimmer/core/test/non-interactive/index.ts
@@ -4,3 +4,4 @@ import './render-test';
 import './each-test';
 import './helper-test';
 import './to-bool-test';
+import './strict-mode-test';

--- a/packages/@glimmer/core/test/non-interactive/render-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/render-test.ts
@@ -243,16 +243,6 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     assert.strictEqual(html, `<button>Count: 0</button>`, 'the component was rendered');
   });
 
-  test('throws an exception if an invoked component is not found', async assert => {
-    assert.expect(1);
-
-    try {
-      await render(createTemplate(`<NonExistent />`));
-    } catch (err) {
-      assert.ok(err.toString().match(/Cannot find component NonExistent in scope/));
-    }
-  });
-
   if (DEBUG) {
     test('accessing properties in template-only components produces a helpful error in development mode', async function(assert) {
       assert.expect(1);

--- a/packages/@glimmer/core/test/non-interactive/strict-mode-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/strict-mode-test.ts
@@ -1,0 +1,67 @@
+import Component from '@glimmer/component';
+
+import {
+  setComponentTemplate,
+  createTemplate,
+} from '@glimmer/core';
+
+import { module, test, render } from '../utils';
+import { DEBUG } from '@glimmer/env';
+
+if (DEBUG) {
+  module(`[@glimmer/core] non-interactive strict-mode tests`, () => {
+    test('throws a helpful error if upvar is used directly in a template invocation and not found in scope', async assert => {
+      assert.throws(() => {
+        class MyComponent extends Component {
+          say = 'Hello Dolly!';
+        }
+
+        setComponentTemplate(MyComponent, createTemplate('<h1>{{say}}</h1>'));
+      }, /Error: Cannot find identifier `say` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `{{this.say}}`/);
+    });
+
+    test('throws a helpful error if upvar is used as an argument and not found in scope', async assert => {
+      assert.throws(() => {
+        class MyComponent extends Component {
+          say = 'Hello Dolly!';
+        }
+
+        function myHelper(param1: unknown): unknown {
+          return param1;
+        }
+
+        setComponentTemplate(MyComponent, createTemplate({ myHelper, }, '<h1>{{myHelper say}}</h1>'));
+      }, /Error: Cannot find identifier `say` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `{{this.say}}`/);
+    });
+
+    test('throws a helpful error if upvar is used as a helper', async assert => {
+      assert.throws(() => {
+        class MyComponent extends Component {
+          say = 'Hello Dolly!';
+        }
+
+        setComponentTemplate(MyComponent, createTemplate('<h1>{{say this.bar}}</h1>'));
+      }, /Error: Cannot find identifier `say` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `{{this.say}}`/);
+    });
+
+    test('throws a helpful error if upvar is used as a modifier', async assert => {
+      assert.throws(() => {
+        class MyComponent extends Component {
+          say = 'Hello Dolly!';
+        }
+
+        setComponentTemplate(MyComponent, createTemplate('<h1 {{say}}>Hello Dolly!</h1>'));
+      }, /Error: Cannot find identifier `say` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `{{this.say}}`/);
+    });
+
+    test('throws a helpful error if upvar is used as a component', async assert => {
+      assert.expect(1);
+
+      try {
+        await render(createTemplate(`<NonExistent />`));
+      } catch (err) {
+        assert.ok(err.toString().match(/Cannot find component `NonExistent` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `<this.NonExistent>`/));
+      }
+    });
+  });
+}


### PR DESCRIPTION
Ensures that non-strict-mode lookups will fail in development builds,
preventing sloppy mode code. This ensures that the API for templates
will be stable as we continue developing strict mode within the VM.

The way it does this currently is to parse the template in DEBUG builds
and compare the upvars within it to the `scope` provided to the
template. If a value isn't found in scope, and is not a built-in, then
it throws.