### PR TITLE
[REFACTOR] Rename Args to TemplateArgs

### DIFF
--- a/packages/@glimmer/component/addon/-private/base-component-manager.ts
+++ b/packages/@glimmer/component/addon/-private/base-component-manager.ts
@@ -1,5 +1,5 @@
 import { DEBUG } from '@glimmer/env';
-import { ComponentManager, ComponentCapabilities, CapturedArgs } from '@glimmer/core';
+import { ComponentManager, ComponentCapabilities, TemplateArgs } from '@glimmer/core';
 import BaseComponent, { ARGS_SET } from './component';
 
 export interface Constructor<T> {
@@ -19,7 +19,7 @@ export default abstract class BaseComponentManager<GlimmerComponent extends Base
 
   createComponent(
     ComponentClass: Constructor<GlimmerComponent>,
-    args: CapturedArgs
+    args: TemplateArgs
   ): GlimmerComponent {
     if (DEBUG) {
       ARGS_SET.set(args.named, true);

--- a/packages/@glimmer/core/index.ts
+++ b/packages/@glimmer/core/index.ts
@@ -13,7 +13,7 @@ export {
   setModifierManager,
 } from './src/managers';
 
-export { Args as CapturedArgs } from './src/interfaces';
+export { TemplateArgs } from './src/interfaces';
 
 export {
   ModifierManager,

--- a/packages/@glimmer/core/src/interfaces.ts
+++ b/packages/@glimmer/core/src/interfaces.ts
@@ -1,6 +1,6 @@
 import { Dict } from '@glimmer/interfaces';
 
-export interface Args<
+export interface TemplateArgs<
   Positional extends unknown[] = unknown[],
   Named extends Dict<unknown> = Dict<unknown>,
 > {

--- a/packages/@glimmer/core/src/managers/component/custom.ts
+++ b/packages/@glimmer/core/src/managers/component/custom.ts
@@ -20,7 +20,7 @@ import { OWNER_KEY, DEFAULT_OWNER } from '../../owner';
 
 import { getComponentManager } from '..';
 import { TemplateMeta } from '../../template';
-import { Args } from '../../interfaces';
+import { TemplateArgs } from '../../interfaces';
 import { argsProxyFor } from '../util';
 
 export const VM_CAPABILITIES: VMComponentCapabilities = {
@@ -75,7 +75,7 @@ export function capabilities(
  */
 export interface ComponentManager<ComponentInstance> {
   capabilities: Capabilities;
-  createComponent(definition: unknown, args: Args): ComponentInstance;
+  createComponent(definition: unknown, args: TemplateArgs): ComponentInstance;
   getContext(instance: ComponentInstance): unknown;
 }
 
@@ -98,7 +98,7 @@ export function hasUpdateHook<ComponentInstance>(
 
 export interface ComponentManagerWithUpdateHook<ComponentInstance>
   extends ComponentManager<ComponentInstance> {
-  updateComponent(instance: ComponentInstance, args: Args): void;
+  updateComponent(instance: ComponentInstance, args: TemplateArgs): void;
 }
 
 export function hasAsyncUpdateHook<ComponentInstance>(
@@ -266,7 +266,7 @@ export class VMCustomComponentState<ComponentInstance> {
     public delegate: ComponentManager<ComponentInstance>,
     public component: ComponentInstance,
     public args: CapturedArguments,
-    public argsProxy: Args
+    public argsProxy: TemplateArgs
   ) {}
 
   destroy(): void {

--- a/packages/@glimmer/core/src/managers/helper.ts
+++ b/packages/@glimmer/core/src/managers/helper.ts
@@ -2,7 +2,7 @@ import { assert } from '@glimmer/util';
 import { Helper as VMHelperFactory, CapturedArguments, VM } from '@glimmer/interfaces';
 import { HelperRootReference } from '@glimmer/reference';
 import { DEBUG } from '@glimmer/env';
-import { Args } from '../interfaces';
+import { TemplateArgs } from '../interfaces';
 import { argsProxyFor } from './util';
 import { OWNER_KEY } from '../owner';
 import { getHelperManager } from '.';
@@ -40,7 +40,7 @@ export interface HelperManager<HelperStateBucket> {
   capabilities: Capabilities;
 
   getValue(bucket: HelperStateBucket): unknown;
-  createHelper(definition: HelperDefinition<HelperStateBucket>, args: Args): HelperStateBucket;
+  createHelper(definition: HelperDefinition<HelperStateBucket>, args: TemplateArgs): HelperStateBucket;
 }
 
 export function hasUpdateHook<HelperStateBucket>(
@@ -51,7 +51,7 @@ export function hasUpdateHook<HelperStateBucket>(
 
 export interface HelperManagerWithUpdateHook<HelperStateBucket>
   extends HelperManager<HelperStateBucket> {
-  updateHelper(bucket: HelperStateBucket, args: Args): void;
+  updateHelper(bucket: HelperStateBucket, args: TemplateArgs): void;
 }
 
 export function hasDestructor<HelperStateBucket>(

--- a/packages/@glimmer/core/src/managers/modifier.ts
+++ b/packages/@glimmer/core/src/managers/modifier.ts
@@ -9,7 +9,7 @@ import {
 import { Tag, createUpdatableTag, track, untrack, combine, updateTag } from '@glimmer/validator';
 import { assert, debugToString } from '@glimmer/util';
 import { SimpleElement } from '@simple-dom/interface';
-import { Args } from '../interfaces';
+import { TemplateArgs } from '../interfaces';
 import debugRenderMessage from '../utils/debug';
 import { argsProxyFor } from './util';
 import { getModifierManager } from '.';
@@ -41,10 +41,10 @@ export function capabilities(
 
 export interface ModifierManager<ModifierStateBucket> {
   capabilities: Capabilities;
-  createModifier(definition: unknown, args: Args): ModifierStateBucket;
-  installModifier(instance: ModifierStateBucket, element: Element, args: Args): void;
-  updateModifier(instance: ModifierStateBucket, args: Args): void;
-  destroyModifier(instance: ModifierStateBucket, args: Args): void;
+  createModifier(definition: unknown, args: TemplateArgs): ModifierStateBucket;
+  installModifier(instance: ModifierStateBucket, element: Element, args: TemplateArgs): void;
+  updateModifier(instance: ModifierStateBucket, args: TemplateArgs): void;
+  destroyModifier(instance: ModifierStateBucket, args: TemplateArgs): void;
 }
 
 export type ModifierDefinition<_Instance = unknown> = {};
@@ -60,7 +60,7 @@ interface SimpleModifierStateBucket {
 class SimpleModifierManager implements ModifierManager<SimpleModifierStateBucket> {
   capabilities = capabilities('3.13');
 
-  createModifier(definition: SimpleModifier, args: Args): SimpleModifierStateBucket {
+  createModifier(definition: SimpleModifier, args: TemplateArgs): SimpleModifierStateBucket {
     if (DEBUG) {
       assert(Object.keys(args.named).length === 0, `You used named arguments with the ${definition.name} modifier, but it is a standard function. Normal functions cannot receive named arguments when used as modifiers.`);
     }
@@ -68,12 +68,12 @@ class SimpleModifierManager implements ModifierManager<SimpleModifierStateBucket
     return { definition };
   }
 
-  installModifier(bucket: SimpleModifierStateBucket, element: Element, args: Args): void {
+  installModifier(bucket: SimpleModifierStateBucket, element: Element, args: TemplateArgs): void {
     bucket.destructor = bucket.definition(element, ...args.positional);
     bucket.element = element;
   }
 
-  updateModifier(bucket: SimpleModifierStateBucket, args: Args): void {
+  updateModifier(bucket: SimpleModifierStateBucket, args: TemplateArgs): void {
     this.destroyModifier(bucket);
     this.installModifier(bucket, bucket.element!, args);
   }
@@ -98,7 +98,7 @@ export class CustomModifierState<ModifierStateBucket> {
     public element: SimpleElement,
     public delegate: ModifierManager<ModifierStateBucket>,
     public modifier: ModifierStateBucket,
-    public argsProxy: Args,
+    public argsProxy: TemplateArgs,
     public capturedArgs: CapturedArguments
   ) {}
 

--- a/packages/@glimmer/core/src/managers/util.ts
+++ b/packages/@glimmer/core/src/managers/util.ts
@@ -2,7 +2,7 @@ import { CapturedArguments } from '@glimmer/interfaces';
 import { consumeTag } from '@glimmer/validator';
 import { assert } from '@glimmer/util';
 import { DEBUG } from '@glimmer/env';
-import { Args } from '../interfaces';
+import { TemplateArgs } from '../interfaces';
 
 function convertToInt(prop: number | string | symbol): number | null {
   if (typeof prop === 'symbol') return null;
@@ -17,7 +17,7 @@ function convertToInt(prop: number | string | symbol): number | null {
 export function argsProxyFor(
   capturedArgs: CapturedArguments,
   type: 'component' | 'helper' | 'modifier'
-): Args {
+): TemplateArgs {
   const { named, positional } = capturedArgs;
 
   const namedHandler: ProxyHandler<{}> = {

--- a/packages/@glimmer/core/test/interactive/modifier-test.ts
+++ b/packages/@glimmer/core/test/interactive/modifier-test.ts
@@ -8,7 +8,7 @@ import {
   createTemplate,
   templateOnlyComponent,
   modifierCapabilities,
-  CapturedArgs,
+  TemplateArgs,
   setModifierManager,
   ModifierManager,
 } from '@glimmer/core';
@@ -33,13 +33,13 @@ class CustomModifierManager implements ModifierManager<CustomModifier> {
     return new factory(this.owner);
   }
 
-  installModifier(instance: CustomModifier, element: Element, args: CapturedArgs): void {
+  installModifier(instance: CustomModifier, element: Element, args: TemplateArgs): void {
     instance.element = element;
     const { positional, named } = args;
     instance.didInsertElement(positional, named);
   }
 
-  updateModifier(instance: CustomModifier, args: CapturedArgs): void {
+  updateModifier(instance: CustomModifier, args: TemplateArgs): void {
     const { positional, named } = args;
     instance.didUpdate(positional, named);
   }

--- a/packages/@glimmer/core/test/utils/custom-helper.ts
+++ b/packages/@glimmer/core/test/utils/custom-helper.ts
@@ -1,5 +1,5 @@
 import {
-  CapturedArgs,
+  TemplateArgs,
   helperCapabilities,
   HelperManager,
   setHelperManager,
@@ -12,7 +12,7 @@ interface Helper<
   Named extends Dict<unknown> = Dict<unknown>,
   Result = unknown
 > {
-  args?: Partial<CapturedArgs<Positional, Named>>;
+  args?: Partial<TemplateArgs<Positional, Named>>;
 
   value?: Result;
 
@@ -33,7 +33,7 @@ class CustomHelperManager implements HelperManager<Helper> {
 
   constructor(private owner: unknown) {}
 
-  createHelper(definition: HelperConstructor, args: CapturedArgs): Helper {
+  createHelper(definition: HelperConstructor, args: TemplateArgs): Helper {
     const instance = new definition();
     instance.args = args;
     setOwner(instance, this.owner);
@@ -45,7 +45,7 @@ class CustomHelperManager implements HelperManager<Helper> {
     return instance.value;
   }
 
-  updateHelper(instance: Helper, args: CapturedArgs): void {
+  updateHelper(instance: Helper, args: TemplateArgs): void {
     instance.args = args;
     instance.update?.();
   }


### PR DESCRIPTION
The Args/CapturedArgs interface was not a very descriptive name, so renaming it
TemplateArgs helps to inform the user what they are meant to be and
self document.