### PR TITLE
[FEAT] Adds a manual `precompileTemplate` API

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,16 @@ module.exports = {
         node: true,
       },
     },
+    {
+      files: [
+        'packages/babel-plugins/**/test/**/*.js',
+      ],
+      env: {
+        es6: true,
+        node: true,
+        mocha: true,
+      },
+    },
     // bin scripts
     {
       files: ['bin/**/*.js'],

--- a/packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/index.js
+++ b/packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/index.js
@@ -1,4 +1,7 @@
 const { precompile } = require('@glimmer/compiler');
+const { parse } = require('@babel/parser');
+const { default: generate } = require('@babel/generator');
+const t = require('@babel/types');
 
 module.exports = function strictTemplatePrecompile(babel, options) {
   const { types: t, parse } = babel;
@@ -75,19 +78,7 @@ module.exports = function strictTemplatePrecompile(babel, options) {
             templateString = templatePath.node.value;
           }
 
-          const compiled = precompile(templateString, precompileOptions);
-          const ast = parse(`(${compiled})`);
-
-          t.traverseFast(ast, node => {
-            if (t.isObjectProperty(node)) {
-              if (node.key.value === 'meta') {
-                node.value.properties.push(t.objectProperty(t.identifier('scope'), scope));
-              }
-              if (t.isStringLiteral(node.key)) {
-                node.key = t.identifier(node.key.value);
-              }
-            }
-          });
+          const ast = _precompileTemplate(parse, templateString, scope, precompileOptions);
 
           path.replaceWith(ast.program.body[0].expression);
         } else {
@@ -97,3 +88,57 @@ module.exports = function strictTemplatePrecompile(babel, options) {
     },
   };
 };
+
+function _precompileTemplate(parse, templateString, scopeNode, precompileOptions) {
+  const compiled = precompile(templateString, precompileOptions);
+  const ast = parse(`(${compiled})`);
+
+  let metaSeen = false;
+
+  t.traverseFast(ast, node => {
+    if (t.isObjectProperty(node)) {
+      if (node.key.value === 'meta') {
+        metaSeen = true;
+        node.value.properties.push(t.objectProperty(t.identifier('scope'), scopeNode));
+      }
+      if (t.isStringLiteral(node.key)) {
+        node.key = t.identifier(node.key.value);
+      }
+    }
+  });
+
+  if (metaSeen === false) {
+    ast.program.body[0].expression.properties.push(
+      t.objectProperty(t.identifier('meta'), t.objectExpression([
+        t.objectProperty(t.identifier('scope'), scopeNode)
+      ]))
+    );
+  }
+
+  return ast;
+}
+
+/**
+ * Allows users to programmatically precompile a template given a list of import
+ * identifiers and the template string. This is meant for usage in custom
+ * template transforms and formats.
+ *
+ * @public
+ * @param template string - the template to be compiled
+ * @param importIdentifiers string[] - the identifiers to import
+ * @param precompileOptions object - the options to be passed to the compiler
+ */
+function precompileTemplate(templateString, importIdentifiers = [], precompileOptions = {}) {
+  const scope = t.arrowFunctionExpression(
+    [],
+    t.objectExpression(
+      importIdentifiers.map(id => t.objectProperty(t.identifier(id), t.identifier(id)))
+    )
+  );
+
+  let ast = _precompileTemplate(parse, templateString, scope, precompileOptions);
+
+  return generate(ast).code;
+}
+
+module.exports.precompileTemplate = precompileTemplate;

--- a/packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/package.json
+++ b/packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/package.json
@@ -11,12 +11,16 @@
   },
   "dependencies": {
     "@babel/core": "^7.5.5",
+    "@babel/generator": "^7.9.4",
     "@babel/helper-module-imports": "^7.0.0",
+    "@babel/parser": "^7.9.4",
+    "@babel/types": "^7.9.0",
     "@glimmer/compiler": "0.50.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.8.3",
     "babel-plugin-tester": "^6.4.0",
+    "chai": "^4.2.0",
     "esm": "^3.2.25",
     "mocha": "^6.2.0"
   }

--- a/packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/test/index.js
+++ b/packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/test/index.js
@@ -1,7 +1,8 @@
-import plugin from '..';
+import plugin, { precompileTemplate } from '..';
 import pluginTester from 'babel-plugin-tester';
 import path from 'path';
 import astTransformTestPluginOptions from './fixtures-options/precompile/ast-transform/options';
+import { expect } from 'chai';
 
 // For correct .babelrc detection inside the fixture directory we need to force babel's cwd and root to be the package root.
 // This will ensure that the tests will run correctly from the mono repo root or package root.
@@ -22,4 +23,44 @@ pluginTester({
       pluginOptions: astTransformTestPluginOptions,
     },
   ],
+});
+
+describe('precompileTemplate', () => {
+  it('works for basic templates', () => {
+    let precompiled = precompileTemplate(`<Component/>`);
+
+    expect(precompiled).to.equal(`({
+  id: "N69jjRzP",
+  block: "{\\"symbols\\":[],\\"statements\\":[[7,\\"Component\\",[],[[],[]],null]],\\"hasEval\\":false,\\"upvars\\":[]}",
+  meta: {
+    scope: () => ({})
+  }
+});`);
+  });
+
+  it('works with imports', () => {
+    let precompiled = precompileTemplate(`<Component/>`, ['Component']);
+
+    expect(precompiled).to.equal(`({
+  id: "N69jjRzP",
+  block: "{\\"symbols\\":[],\\"statements\\":[[7,\\"Component\\",[],[[],[]],null]],\\"hasEval\\":false,\\"upvars\\":[]}",
+  meta: {
+    scope: () => ({
+      Component: Component
+    })
+  }
+});`);
+  });
+
+  it('can apply precompile transforms', () => {
+    let precompiled = precompileTemplate('{{bad}}<h1>Hello world</h1>', [], astTransformTestPluginOptions.precompile);
+
+    expect(precompiled).to.equal(`({
+  id: "k5+y7pkD",
+  block: "{\\"symbols\\":[],\\"statements\\":[[9,\\"h1\\",true],[10],[1,1,0,0,\\"Hello world\\"],[11]],\\"hasEval\\":false,\\"upvars\\":[]}",
+  meta: {
+    scope: () => ({})
+  }
+});`);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,7 +57,7 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/generator@^7.8.6":
+"@babel/generator@^7.8.6", "@babel/generator@^7.9.4":
   version "7.9.4"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.4.tgz#12441e90c3b3c4159cdecf312075bf1a8ce2dbce"
   integrity sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==
@@ -310,7 +310,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.4.5", "@babel/parser@^7.8.6":
+"@babel/parser@^7.4.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.4":
   version "7.9.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.4.tgz#68a35e6b0319bbc014465be43828300113f2f2e8"
   integrity sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==
@@ -4032,7 +4032,7 @@ chai@^3.3.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-chai@^4.1.0:
+chai@^4.1.0, chai@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
   integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==


### PR DESCRIPTION
This API allows users to precompile templates themselves, so they can
build babel transforms on top of them. The API returns a string value
that users can simply insert into their output.