### PR TITLE
[BUGFIX] Binds EnvironmentDelegate.protocolForUrl

### DIFF
--- a/packages/@glimmer/core/src/environment/delegates.ts
+++ b/packages/@glimmer/core/src/environment/delegates.ts
@@ -49,16 +49,9 @@ if (DEBUG) {
 export class ClientEnvDelegate extends BaseEnvDelegate {
   isInteractive = true;
 
-  private uselessAnchor: HTMLAnchorElement;
+  private uselessAnchor = self.document.createElement('a');
 
-  constructor() {
-    super();
-    // TODO - required for `protocolForURL` - seek alternative approach
-    // e.g. see `installPlatformSpecificProtocolForURL` in Ember
-    this.uselessAnchor = self.document.createElement('a');
-  }
-
-  protocolForURL(url: string): string {
+  protocolForURL = (url: string): string => {
     // TODO - investigate alternative approaches
     // e.g. see `installPlatformSpecificProtocolForURL` in Ember
     this.uselessAnchor.href = url;

--- a/packages/@glimmer/core/test/non-interactive/render-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/render-test.ts
@@ -243,6 +243,24 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     assert.strictEqual(html, `<button>Count: 0</button>`, 'the component was rendered');
   });
 
+  test('it can set a dynamic href on an anchor', async assert => {
+    class MyComponent extends Component {}
+
+    setComponentTemplate(MyComponent, createTemplate(`<a href={{@href}}>Link</a>`));
+
+    const html = await render(MyComponent, { args: { href: 'www.example.com' } });
+    assert.strictEqual(html, '<a href="www.example.com">Link</a>', 'the template was rendered');
+  });
+
+  test('it can set a dynamic src on an img', async assert => {
+    class MyComponent extends Component {}
+
+    setComponentTemplate(MyComponent, createTemplate(`<img src={{@src}}/>`));
+
+    const html = await render(MyComponent, { args: { src: './logo.svg' } });
+    assert.strictEqual(html, '<img src="./logo.svg">', 'the template was rendered');
+  });
+
   if (DEBUG) {
     test('accessing properties in template-only components produces a helpful error in development mode', async function(assert) {
       assert.expect(1);


### PR DESCRIPTION
We made a decision upstream to pluck the delegate functions and move
them around so that they could be looked up more quickly when used. In
most cases this is fine, because the delegate functions are pure and
non-stateful. The `protocolForUrl` function is not, but this was known
at the time, and the plan was to bind it like in this PR. It was an
oversight in the upgrade process.

Tests added to ensure we remember if future changes occur.