### PR TITLE
Update to prettier@2

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,6 +14,6 @@ typescript.ts
 babel.js
 
 **/fixtures/**/*.js
-**/fixture-options/**/*.js
+**/fixtures-options/**/*.js
 
 test/types/utils.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   extends: [
     'eslint:recommended',
-    'prettier',
+    'plugin:prettier/recommended',
   ],
   plugins: ['@typescript-eslint', 'prettier'],
   overrides: [

--- a/bin/build.js
+++ b/bin/build.js
@@ -7,15 +7,15 @@ const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
 const glob = promisify(require('glob'));
 
-(async function() {
+(async function () {
   process.chdir(path.join(__dirname, '..'));
 
   await buildTypescript('dist/modules', 'es2015');
   await buildTypescript('dist/commonjs', 'commonjs');
 
   const packages = (await glob('dist/modules/{@*/*,!(@*)}'))
-    .map(pkg => pkg.replace('dist/modules/', ''))
-    .flatMap(pkg => [
+    .map((pkg) => pkg.replace('dist/modules/', ''))
+    .flatMap((pkg) => [
       {
         from: path.join('dist', 'commonjs', pkg),
         to: path.join('packages', pkg, 'dist', 'commonjs'),
@@ -26,8 +26,8 @@ const glob = promisify(require('glob'));
       },
     ]);
 
-  await remove(packages.map(pkg => pkg.to));
-  await createDirs(packages.map(pkg => pkg.to));
+  await remove(packages.map((pkg) => pkg.to));
+  await createDirs(packages.map((pkg) => pkg.to));
   await move(packages);
 
   console.log('\n\nDone');
@@ -46,14 +46,14 @@ async function buildTypescript(outDir, moduleKind = 'es2015') {
 }
 
 function createDirs(paths) {
-  return each(paths, pathOfDir => {
+  return each(paths, (pathOfDir) => {
     console.log(`Creating Dir ${pathOfDir}`);
     return fs.mkdirp(pathOfDir);
   });
 }
 
 function remove(paths) {
-  return each(paths, pathOfDir => {
+  return each(paths, (pathOfDir) => {
     console.log(`Removing ${pathOfDir}`);
     return fs.remove(pathOfDir);
   });

--- a/bin/clean.js
+++ b/bin/clean.js
@@ -5,7 +5,7 @@ const { promisify } = require('util');
 
 const glob = promisify(require('glob'));
 
-(async function() {
+(async function () {
   await remove(['./tmp']);
   await remove(await glob('./packages/@glimmer/*/dist'));
 
@@ -13,7 +13,7 @@ const glob = promisify(require('glob'));
 })();
 
 function remove(paths) {
-  return each(paths, pathOfDir => {
+  return each(paths, (pathOfDir) => {
     console.log(`Removing ${pathOfDir}`);
     return fs.remove(pathOfDir);
   });

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "glob": "^7.1.6",
     "lerna-changelog": "^1.0.1",
     "mkdirp": "^1.0.3",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.2",
     "qunit": "^2.9.3",
     "release-it": "^13.5.1",
     "release-it-lerna-changelog": "^2.1.2",

--- a/packages/@glimmer/blueprint/files/.babelrc.js
+++ b/packages/@glimmer/blueprint/files/.babelrc.js
@@ -1,4 +1,4 @@
-module.exports = function(api) {
+module.exports = function (api) {
   return {
     plugins: [
       ['@glimmer/babel-plugin-glimmer-env', { DEBUG: !api.env('production') }],

--- a/packages/@glimmer/blueprint/files/package.json
+++ b/packages/@glimmer/blueprint/files/package.json
@@ -64,7 +64,7 @@
     ],
     "extends": [
       "eslint:recommended",
-      "prettier"
+      "plugin:prettier/recommended"
     ],
     "ignorePatterns": [
       "dist/",

--- a/packages/@glimmer/blueprint/files/tests/rendering/App.test.js
+++ b/packages/@glimmer/blueprint/files/tests/rendering/App.test.js
@@ -3,7 +3,7 @@ import { module, test, renderComponent } from '../util';
 import App from '../../src/App';
 
 module('App test', () => {
-  test('it works', async assert => {
+  test('it works', async (assert) => {
     await renderComponent(App);
 
     assert.dom('h1').containsText('hello, glimmer!');

--- a/packages/@glimmer/blueprint/index.js
+++ b/packages/@glimmer/blueprint/index.js
@@ -32,7 +32,7 @@ module.exports = {
     let files = this._super.files.apply(this, arguments);
 
     if (this._shouldIncludeYarnLockInFiles()) {
-      files = files.filter(file => file !== 'yarn.lock');
+      files = files.filter((file) => file !== 'yarn.lock');
     }
 
     return files;

--- a/packages/@glimmer/component/addon/-private/base-component-manager.ts
+++ b/packages/@glimmer/component/addon/-private/base-component-manager.ts
@@ -8,7 +8,6 @@ export interface Constructor<T> {
 
 export default abstract class BaseComponentManager<GlimmerComponent extends BaseComponent>
   implements ComponentManager<GlimmerComponent> {
-
   abstract capabilities: ComponentCapabilities;
 
   private owner: unknown;

--- a/packages/@glimmer/component/addon/-private/ember-component-manager.ts
+++ b/packages/@glimmer/component/addon/-private/ember-component-manager.ts
@@ -55,7 +55,6 @@ class EmberGlimmerComponentManager extends BaseComponentManager<GlimmerComponent
   }
 }
 
-
 interface EmberGlimmerComponentManager {
   updateComponent?: (component: GlimmerComponent, args: CapturedArgs) => void;
 }

--- a/packages/@glimmer/component/config/ember-try.js
+++ b/packages/@glimmer/component/config/ember-try.js
@@ -2,12 +2,12 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-module.exports = function() {
+module.exports = function () {
   return Promise.all([
     getChannelURL('release'),
     getChannelURL('beta'),
     getChannelURL('canary'),
-  ]).then(urls => {
+  ]).then((urls) => {
     return {
       useYarn: true,
       scenarios: [

--- a/packages/@glimmer/component/config/environment.js
+++ b/packages/@glimmer/component/config/environment.js
@@ -1,5 +1,5 @@
 'use strict';
 
-module.exports = function(/* environment, appConfig */) {
+module.exports = function (/* environment, appConfig */) {
   return {};
 };

--- a/packages/@glimmer/component/ember-cli-build.js
+++ b/packages/@glimmer/component/ember-cli-build.js
@@ -3,7 +3,7 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 const Funnel = require('broccoli-funnel');
 
-module.exports = function(defaults) {
+module.exports = function (defaults) {
   const app = new EmberAddon(defaults, {
     configPath: './test/ember/dummy/config/environment',
     trees: {

--- a/packages/@glimmer/component/test/ember/dummy/app/router.js
+++ b/packages/@glimmer/component/test/ember/dummy/app/router.js
@@ -6,7 +6,7 @@ const Router = EmberRouter.extend({
   rootURL: config.rootURL,
 });
 
-Router.map(function() {
+Router.map(function () {
   this.route('conference-speakers');
 });
 

--- a/packages/@glimmer/component/test/ember/dummy/config/environment.js
+++ b/packages/@glimmer/component/test/ember/dummy/config/environment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(environment) {
+module.exports = function (environment) {
   const ENV = {
     modulePrefix: 'dummy',
     environment,

--- a/packages/@glimmer/component/test/ember/integration/components/glimmer-component-guide-test.js
+++ b/packages/@glimmer/component/test/ember/integration/components/glimmer-component-guide-test.js
@@ -3,10 +3,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | glimmer.js guide example', function(hooks) {
+module('Integration | Component | glimmer.js guide example', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function(assert) {
+  hooks.beforeEach(function (assert) {
     assert.validateSpeakers = (speakerNames, currentSpeaker) => {
       const items = this.element.querySelectorAll('li');
       assert.equal(items.length, speakerNames.length, 'correct number of entires found');
@@ -19,13 +19,13 @@ module('Integration | Component | glimmer.js guide example', function(hooks) {
     };
   });
 
-  test('renders', async function(assert) {
+  test('renders', async function (assert) {
     await render(hbs`<ConferenceSpeakers />`);
 
     assert.validateSpeakers(['Tom', 'Yehuda', 'Ed'], 'Tom');
   });
 
-  test('cycles through speakers', async function(assert) {
+  test('cycles through speakers', async function (assert) {
     await render(hbs`<ConferenceSpeakers />`);
 
     assert.validateSpeakers(['Tom', 'Yehuda', 'Ed'], 'Tom');

--- a/packages/@glimmer/component/test/ember/integration/components/glimmer-component-test.js
+++ b/packages/@glimmer/component/test/ember/integration/components/glimmer-component-test.js
@@ -8,12 +8,12 @@ import { set, computed } from '@ember/object';
 
 import { gte } from 'ember-compatibility-helpers';
 
-module('Integration | Component | @glimmer/component', function(hooks) {
+module('Integration | Component | @glimmer/component', function (hooks) {
   let InstrumentedComponent;
 
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function(assert) {
+  hooks.beforeEach(function (assert) {
     InstrumentedComponent = class extends GlimmerComponent {
       constructor() {
         super(...arguments);
@@ -26,7 +26,7 @@ module('Integration | Component | @glimmer/component', function(hooks) {
     };
   });
 
-  test('it can render with curlies (no args)', async function(assert) {
+  test('it can render with curlies (no args)', async function (assert) {
     this.owner.register('component:under-test', InstrumentedComponent);
 
     await render(hbs`{{under-test}}`);
@@ -38,7 +38,7 @@ module('Integration | Component | @glimmer/component', function(hooks) {
     assert.verifySteps(['willDestroy'], 'post destroy steps');
   });
 
-  test('it can render and update with curlies (args)', async function(assert) {
+  test('it can render and update with curlies (args)', async function (assert) {
     this.owner.register('component:under-test', InstrumentedComponent);
     this.owner.register('template:components/under-test', hbs`<p>{{@text}}</p>`);
 
@@ -63,7 +63,7 @@ module('Integration | Component | @glimmer/component', function(hooks) {
     assert.verifySteps(['willDestroy'], 'post destroy steps');
   });
 
-  test('it can render with angles (no args)', async function(assert) {
+  test('it can render with angles (no args)', async function (assert) {
     this.owner.register('component:under-test', InstrumentedComponent);
 
     await render(hbs`<UnderTest />`);
@@ -75,7 +75,7 @@ module('Integration | Component | @glimmer/component', function(hooks) {
     assert.verifySteps(['willDestroy'], 'post destroy steps');
   });
 
-  test('it can render and update with angles (args)', async function(assert) {
+  test('it can render and update with angles (args)', async function (assert) {
     this.owner.register('component:under-test', InstrumentedComponent);
     this.owner.register('template:components/under-test', hbs`<p>{{@text}}</p>`);
 
@@ -100,7 +100,7 @@ module('Integration | Component | @glimmer/component', function(hooks) {
     assert.verifySteps(['willDestroy'], 'post destroy steps');
   });
 
-  test('it can use args in component', async function(assert) {
+  test('it can use args in component', async function (assert) {
     this.owner.register(
       'component:under-test',
       class extends GlimmerComponent {
@@ -116,7 +116,7 @@ module('Integration | Component | @glimmer/component', function(hooks) {
     assert.dom('p').hasText('HELLO!');
   });
 
-  test('it can use args in constructor', async function(assert) {
+  test('it can use args in constructor', async function (assert) {
     this.owner.register(
       'component:under-test',
       class extends GlimmerComponent {
@@ -134,7 +134,7 @@ module('Integration | Component | @glimmer/component', function(hooks) {
     assert.dom('p').hasText('HELLO!');
   });
 
-  test('it can use get/set to recompute for changes', async function(assert) {
+  test('it can use get/set to recompute for changes', async function (assert) {
     this.owner.register(
       'component:under-test',
       class extends GlimmerComponent {
@@ -164,7 +164,7 @@ module('Integration | Component | @glimmer/component', function(hooks) {
     assert.dom('p').hasText('Count: 2');
   });
 
-  test('does not update for non-tracked property changes', async function(assert) {
+  test('does not update for non-tracked property changes', async function (assert) {
     this.owner.register(
       'component:under-test',
       class extends GlimmerComponent {
@@ -202,7 +202,7 @@ module('Integration | Component | @glimmer/component', function(hooks) {
     assert.dom('p').hasText('Count: 0');
   });
 
-  test('it has an owner', async function(assert) {
+  test('it has an owner', async function (assert) {
     this.owner.register(
       'component:under-test',
       class extends GlimmerComponent {
@@ -219,7 +219,7 @@ module('Integration | Component | @glimmer/component', function(hooks) {
     assert.dom('p').hasText('Environment: test');
   });
 
-  test('computed properties can depend on args', async function(assert) {
+  test('computed properties can depend on args', async function (assert) {
     this.owner.register(
       'component:under-test',
       class extends InstrumentedComponent {
@@ -253,7 +253,7 @@ module('Integration | Component | @glimmer/component', function(hooks) {
   });
 
   if (gte('3.13.0-alpha.0')) {
-    test('args autotrack correctly', async function(assert) {
+    test('args autotrack correctly', async function (assert) {
       this.owner.register(
         'component:under-test',
         class extends InstrumentedComponent {

--- a/packages/@glimmer/component/test/interactive/args-test.ts
+++ b/packages/@glimmer/component/test/interactive/args-test.ts
@@ -5,7 +5,7 @@ import { setComponentTemplate, createTemplate } from '@glimmer/core';
 import { module, test, render, settled } from '@glimmer/core/test/utils';
 
 module('[@glimmer/component] Component Arguments', () => {
-  test('Getters that depend on `args` re-render correctly', async function(assert) {
+  test('Getters that depend on `args` re-render correctly', async function (assert) {
     assert.expect(2);
 
     let parent: ParentComponent;

--- a/packages/@glimmer/component/test/interactive/lifecycle-hook-test.ts
+++ b/packages/@glimmer/component/test/interactive/lifecycle-hook-test.ts
@@ -5,7 +5,7 @@ import { module, test, render, settled } from '@glimmer/core/test/utils';
 import { setComponentTemplate, createTemplate } from '@glimmer/core';
 
 module('[@glimmer/component] Lifecycle Hooks', () => {
-  test('Lifecycle hook ordering', async function(assert) {
+  test('Lifecycle hook ordering', async function (assert) {
     assert.expect(2);
 
     let invocations: [string, string][] = [];

--- a/packages/@glimmer/core/index.ts
+++ b/packages/@glimmer/core/index.ts
@@ -7,11 +7,7 @@ export {
 
 export { BaseEnvDelegate } from './src/environment/delegates';
 
-export {
-  setComponentManager,
-  setHelperManager,
-  setModifierManager,
-} from './src/managers';
+export { setComponentManager, setHelperManager, setModifierManager } from './src/managers';
 
 export { TemplateArgs } from './src/interfaces';
 

--- a/packages/@glimmer/core/src/environment/delegates.ts
+++ b/packages/@glimmer/core/src/environment/delegates.ts
@@ -2,7 +2,6 @@ import { EnvironmentDelegate } from '@glimmer/runtime';
 import { Option, Dict } from '@glimmer/interfaces';
 import { IteratorDelegate } from '@glimmer/reference';
 
-
 import { isNativeIterable, NativeIterator } from './iterator';
 import { DEBUG } from '@glimmer/env';
 import toBool from './to-bool';
@@ -21,7 +20,7 @@ export abstract class BaseEnvDelegate implements EnvironmentDelegate {
   // Match Ember's toBool semantics for cross-compatibility
   toBool = toBool;
 
-  toIterator(value: unknown): Option<IteratorDelegate>  {
+  toIterator(value: unknown): Option<IteratorDelegate> {
     if (isNativeIterable(value)) {
       return NativeIterator.from(value);
     }
@@ -32,13 +31,18 @@ export abstract class BaseEnvDelegate implements EnvironmentDelegate {
 
 if (DEBUG) {
   // This is only possible in `key` on {{each}}
-  (BaseEnvDelegate.prototype as EnvironmentDelegate).getPath = (obj: unknown, path: string): unknown => {
+  (BaseEnvDelegate.prototype as EnvironmentDelegate).getPath = (
+    obj: unknown,
+    path: string
+  ): unknown => {
     if (path.includes('.')) {
-      throw new Error('You attempted to get a path with a `.` in it, but Glimmer.js does not support paths with dots.');
+      throw new Error(
+        'You attempted to get a path with a `.` in it, but Glimmer.js does not support paths with dots.'
+      );
     }
 
     return (obj as Dict)[path];
-  }
+  };
 }
 
 /**
@@ -56,5 +60,5 @@ export class ClientEnvDelegate extends BaseEnvDelegate {
     // e.g. see `installPlatformSpecificProtocolForURL` in Ember
     this.uselessAnchor.href = url;
     return this.uselessAnchor.protocol;
-  }
+  };
 }

--- a/packages/@glimmer/core/src/environment/iterator.ts
+++ b/packages/@glimmer/core/src/environment/iterator.ts
@@ -2,7 +2,7 @@ import { Option } from '@glimmer/interfaces';
 import { IteratorDelegate } from '@glimmer/reference';
 
 export function isNativeIterable(value: unknown): value is Iterable<unknown> {
-  return typeof value === 'object' && value !== null && Symbol.iterator in value
+  return typeof value === 'object' && value !== null && Symbol.iterator in value;
 }
 
 export class NativeIterator<T = unknown> implements IteratorDelegate {
@@ -26,7 +26,7 @@ export class NativeIterator<T = unknown> implements IteratorDelegate {
     return false;
   }
 
-  next(): Option<{ value: T, memo: number }> {
+  next(): Option<{ value: T; memo: number }> {
     const { iterable, result, position } = this;
 
     if (result.done) {

--- a/packages/@glimmer/core/src/interfaces.ts
+++ b/packages/@glimmer/core/src/interfaces.ts
@@ -2,7 +2,7 @@ import { Dict } from '@glimmer/interfaces';
 
 export interface TemplateArgs<
   Positional extends unknown[] = unknown[],
-  Named extends Dict<unknown> = Dict<unknown>,
+  Named extends Dict<unknown> = Dict<unknown>
 > {
   named: Named;
   positional: Positional;

--- a/packages/@glimmer/core/src/managers/component/custom.ts
+++ b/packages/@glimmer/core/src/managers/component/custom.ts
@@ -188,11 +188,7 @@ export default class CustomComponentManager<ComponentInstance>
     return new VMCustomComponentState(env, delegate, component, capturedArgs, argsProxy);
   }
 
-  update({
-    delegate,
-    component,
-    argsProxy,
-  }: VMCustomComponentState<ComponentInstance>): void {
+  update({ delegate, component, argsProxy }: VMCustomComponentState<ComponentInstance>): void {
     if (hasUpdateHook(delegate)) {
       delegate.updateComponent(component, argsProxy);
     }

--- a/packages/@glimmer/core/src/managers/helper.ts
+++ b/packages/@glimmer/core/src/managers/helper.ts
@@ -40,7 +40,10 @@ export interface HelperManager<HelperStateBucket> {
   capabilities: Capabilities;
 
   getValue(bucket: HelperStateBucket): unknown;
-  createHelper(definition: HelperDefinition<HelperStateBucket>, args: TemplateArgs): HelperStateBucket;
+  createHelper(
+    definition: HelperDefinition<HelperStateBucket>,
+    args: TemplateArgs
+  ): HelperStateBucket;
 }
 
 export function hasUpdateHook<HelperStateBucket>(
@@ -116,10 +119,7 @@ export function vmHelperFactoryFor<HelperStateBucket>(
   definition: HelperDefinition<HelperStateBucket>
 ): VMHelperFactory {
   return (args, vm): HelperRootReference => {
-    const owner = vm
-      .dynamicScope()
-      .get(OWNER_KEY)
-      .value() as object;
+    const owner = vm.dynamicScope().get(OWNER_KEY).value() as object;
     const manager = getHelperManager(owner, definition)!;
     const capturedArgs = args.capture();
 

--- a/packages/@glimmer/core/src/managers/modifier.ts
+++ b/packages/@glimmer/core/src/managers/modifier.ts
@@ -62,7 +62,10 @@ class SimpleModifierManager implements ModifierManager<SimpleModifierStateBucket
 
   createModifier(definition: SimpleModifier, args: TemplateArgs): SimpleModifierStateBucket {
     if (DEBUG) {
-      assert(Object.keys(args.named).length === 0, `You used named arguments with the ${definition.name} modifier, but it is a standard function. Normal functions cannot receive named arguments when used as modifiers.`);
+      assert(
+        Object.keys(args.named).length === 0,
+        `You used named arguments with the ${definition.name} modifier, but it is a standard function. Normal functions cannot receive named arguments when used as modifiers.`
+      );
     }
 
     return { definition };

--- a/packages/@glimmer/core/src/managers/util.ts
+++ b/packages/@glimmer/core/src/managers/util.ts
@@ -91,7 +91,7 @@ export function argsProxyFor(
   const positionalTarget: unknown[] = [];
 
   if (DEBUG) {
-    const setHandler = function(_target: unknown, prop: symbol | string | number): never {
+    const setHandler = function (_target: unknown, prop: symbol | string | number): never {
       throw new Error(
         `You attempted to set ${String(
           prop

--- a/packages/@glimmer/core/src/owner.ts
+++ b/packages/@glimmer/core/src/owner.ts
@@ -7,14 +7,15 @@ export const OWNER_KEY = `__OWNER_${Math.floor(Math.random() * Date.now())}__`;
 export let DEFAULT_OWNER = {};
 
 if (DEBUG) {
-  const OWNER_ERROR = 'You attempted to use the Owner for a component, modifier, or helper, but did not provide an owner to `renderComponent`.';
+  const OWNER_ERROR =
+    'You attempted to use the Owner for a component, modifier, or helper, but did not provide an owner to `renderComponent`.';
   DEFAULT_OWNER = new Proxy(DEFAULT_OWNER, {
     get(): never {
       throw new Error(OWNER_ERROR);
     },
     set(): never {
       throw new Error(OWNER_ERROR);
-    }
+    },
   });
 }
 

--- a/packages/@glimmer/core/src/render-component/built-ins.ts
+++ b/packages/@glimmer/core/src/render-component/built-ins.ts
@@ -6,8 +6,10 @@ import toBool from '../environment/to-bool';
 export function ifHelper(args: VMArguments, vm: VM): HelperRootReference {
   return new HelperRootReference(
     ({ positional }) => {
-      if (DEBUG && positional.length < 2 || positional.length > 3) {
-        throw new Error('The inline form of the `if` helper expects two or three arguments, e.g. `{{if trialExpired "Expired" expiryDate}}`.');
+      if ((DEBUG && positional.length < 2) || positional.length > 3) {
+        throw new Error(
+          'The inline form of the `if` helper expects two or three arguments, e.g. `{{if trialExpired "Expired" expiryDate}}`.'
+        );
       }
 
       const condition = positional.at(0);
@@ -23,5 +25,5 @@ export function ifHelper(args: VMArguments, vm: VM): HelperRootReference {
     args.capture(),
     vm.env,
     'if'
-  )
+  );
 }

--- a/packages/@glimmer/core/src/render-component/resolvers.ts
+++ b/packages/@glimmer/core/src/render-component/resolvers.ts
@@ -85,7 +85,8 @@ export class CompileTimeResolver implements ResolverDelegate {
 
   lookupHelper(name: string, referrer: TemplateMeta): Option<number> {
     const scope = referrer.scope();
-    const { helper, handle } = builtInHelpers[name] || vmDefinitionForHelper(scope[name] as HelperDefinition);
+    const { helper, handle } =
+      builtInHelpers[name] || vmDefinitionForHelper(scope[name] as HelperDefinition);
 
     this.inner.registry[handle] = helper;
     return handle;
@@ -108,7 +109,9 @@ export class CompileTimeResolver implements ResolverDelegate {
     const ComponentDefinition = scope[name] as ComponentDefinition;
 
     if (DEBUG && ComponentDefinition === undefined) {
-      throw new Error(`Cannot find component \`${name}\` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add \`this\` to it: \`<this.${name}>\``);
+      throw new Error(
+        `Cannot find component \`${name}\` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add \`this\` to it: \`<this.${name}>\``
+      );
     }
 
     const definition = vmDefinitionForComponent(ComponentDefinition);

--- a/packages/@glimmer/core/src/render-component/vm-definitions.ts
+++ b/packages/@glimmer/core/src/render-component/vm-definitions.ts
@@ -26,7 +26,6 @@ export interface VMModifierDefinitionWithHandle extends VMModifierDefinition {
   handle: number;
 }
 
-
 export interface VMHelperDefinition {
   helper: VMHelperFactory;
   handle: number;
@@ -41,21 +40,29 @@ export interface Modifier {
 
 let HANDLE = 0;
 
-const VM_COMPONENT_DEFINITIONS = new WeakMap<ComponentDefinition, VMComponentDefinitionWithHandle>();
+const VM_COMPONENT_DEFINITIONS = new WeakMap<
+  ComponentDefinition,
+  VMComponentDefinitionWithHandle
+>();
 const VM_HELPER_DEFINITIONS = new WeakMap<HelperDefinition, VMHelperDefinition>();
 const VM_MODIFIER_DEFINITIONS = new WeakMap<ModifierDefinition, VMModifierDefinitionWithHandle>();
 
 export function vmDefinitionForComponent(
   ComponentDefinition: ComponentDefinition
 ): VMComponentDefinitionWithHandle {
-  return VM_COMPONENT_DEFINITIONS.get(ComponentDefinition) || createVMComponentDefinition(ComponentDefinition);
+  return (
+    VM_COMPONENT_DEFINITIONS.get(ComponentDefinition) ||
+    createVMComponentDefinition(ComponentDefinition)
+  );
 }
 
 export function vmDefinitionForHelper(Helper: HelperDefinition): VMHelperDefinition {
   return VM_HELPER_DEFINITIONS.get(Helper) || createVMHelperDefinition(Helper);
 }
 
-export function vmDefinitionForModifier(Modifier: ModifierDefinition): VMModifierDefinitionWithHandle {
+export function vmDefinitionForModifier(
+  Modifier: ModifierDefinition
+): VMModifierDefinitionWithHandle {
   return VM_MODIFIER_DEFINITIONS.get(Modifier) || createVMModifierDefinition(Modifier);
 }
 
@@ -72,7 +79,7 @@ function handleForBuiltIn(builtIn: object): number {
     throw new Error('attempted to register the same built-in twice');
   }
 
-  return HANDLE++
+  return HANDLE++;
 }
 
 export function vmDefinitionForBuiltInHelper(helper: VMHelperFactory): VMHelperDefinition {
@@ -116,9 +123,7 @@ function createVMHelperDefinition(userDefinition: HelperDefinition): VMHelperDef
   return definition;
 }
 
-function createVMModifierDefinition(
-  Modifier: ModifierDefinition
-): VMModifierDefinitionWithHandle {
+function createVMModifierDefinition(Modifier: ModifierDefinition): VMModifierDefinitionWithHandle {
   const definition = new VMCustomModifierDefinition(HANDLE++, Modifier);
 
   VM_MODIFIER_DEFINITIONS.set(Modifier, definition);

--- a/packages/@glimmer/core/src/template.ts
+++ b/packages/@glimmer/core/src/template.ts
@@ -38,7 +38,9 @@ export function setComponentTemplate<T extends object>(
     if (block.upvars) {
       for (const upvar of block.upvars) {
         if (!(upvar in builtInHelpers) && scope[upvar] === undefined) {
-          throw new Error(`Cannot find identifier \`${upvar}\` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add \`this\` to it: \`{{this.${upvar}}}\``);
+          throw new Error(
+            `Cannot find identifier \`${upvar}\` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add \`this\` to it: \`{{this.${upvar}}}\``
+          );
         }
       }
     }

--- a/packages/@glimmer/core/src/utils/unbindable-function.ts
+++ b/packages/@glimmer/core/src/utils/unbindable-function.ts
@@ -1,14 +1,16 @@
 import { DEBUG } from '@glimmer/env';
 
-export let unbindableFunction: undefined | (<T, U>(func: (...args: T[]) => U) => ((...args: T[]) => U));
+export let unbindableFunction:
+  | undefined
+  | (<T, U>(func: (...args: T[]) => U) => (...args: T[]) => U);
 
 if (DEBUG) {
   unbindableFunction = <T, U>(func: (...args: T[]) => U): ((...args: T[]) => U) => {
     const assertOnProperty = (property: string | number | symbol): never => {
       throw new Error(
-        `You accessed \`this.${String(
-          property
-        )}\` from a function passed to the ${func.name}, but the function itself was not bound to a valid \`this\` context. Consider updating to usage of \`@action\`.`
+        `You accessed \`this.${String(property)}\` from a function passed to the ${
+          func.name
+        }, but the function itself was not bound to a valid \`this\` context. Consider updating to usage of \`@action\`.`
       );
     };
 
@@ -30,5 +32,5 @@ if (DEBUG) {
     );
 
     return func.bind(untouchableThis);
-  }
+  };
 }

--- a/packages/@glimmer/core/test/interactive/fn-test.ts
+++ b/packages/@glimmer/core/test/interactive/fn-test.ts
@@ -7,7 +7,7 @@ import { on, action } from '@glimmer/modifier';
 import { setComponentTemplate, createTemplate, templateOnlyComponent } from '@glimmer/core';
 
 module('[@glimmer/core] interactive - {{fn}}', () => {
-  test('can curry arguments via fn', async function(assert) {
+  test('can curry arguments via fn', async function (assert) {
     assert.expect(9);
 
     let helloWorldComponent: HelloWorld;
@@ -63,7 +63,7 @@ module('[@glimmer/core] interactive - {{fn}}', () => {
     assert.ok(passedEvent! instanceof MouseEvent);
   });
 
-  test('functions can be curried multiple times', async function(assert) {
+  test('functions can be curried multiple times', async function (assert) {
     assert.expect(2);
 
     let parentComponent: ParentComponent;
@@ -101,7 +101,10 @@ module('[@glimmer/core] interactive - {{fn}}', () => {
 
     setComponentTemplate(
       ParentComponent,
-      createTemplate({ Child, fn }, '<div><Child @userDidClick={{fn this.userDidClick 1 2}} /></div>')
+      createTemplate(
+        { Child, fn },
+        '<div><Child @userDidClick={{fn this.userDidClick 1 2}} /></div>'
+      )
     );
 
     await render(ParentComponent);
@@ -114,7 +117,7 @@ module('[@glimmer/core] interactive - {{fn}}', () => {
     assert.deepEqual(passed, [1, 2, 3, 4, 5, 6]);
   });
 
-  test('action helper invoked without a function raises an error', function(assert) {
+  test('action helper invoked without a function raises an error', function (assert) {
     class Parent extends Component {}
 
     setComponentTemplate(
@@ -125,7 +128,7 @@ module('[@glimmer/core] interactive - {{fn}}', () => {
     assert.rejects(render(Parent), /fn must receive a function as its first parameter/);
   });
 
-  test('fn helper invoked without a parameter raises an error', function(assert) {
+  test('fn helper invoked without a parameter raises an error', function (assert) {
     class Parent extends Component {
       @action
       exists(): void {
@@ -138,7 +141,9 @@ module('[@glimmer/core] interactive - {{fn}}', () => {
       createTemplate({ on, fn }, '<button {{on "click" (fn this.exists)}}></button>')
     );
 
-    assert.rejects(render(Parent), /fn must receive at least one argument to pass to the function, otherwise there is no need to use fn./);
+    assert.rejects(
+      render(Parent),
+      /fn must receive at least one argument to pass to the function, otherwise there is no need to use fn./
+    );
   });
 });
-

--- a/packages/@glimmer/core/test/interactive/helper-test.ts
+++ b/packages/@glimmer/core/test/interactive/helper-test.ts
@@ -11,7 +11,7 @@ import {
 import { helper } from '../utils/custom-helper';
 
 module('[@glimmer/core] interactive - helper', () => {
-  test('simple helpers update when args change', async assert => {
+  test('simple helpers update when args change', async (assert) => {
     let count = 0;
 
     function myHelper(name: string, greeting: string): string {
@@ -48,7 +48,7 @@ module('[@glimmer/core] interactive - helper', () => {
     assert.equal(count, 2, 'simple helper reran after positional args changed');
   });
 
-  test('custom helpers update when positional args change', async assert => {
+  test('custom helpers update when positional args change', async (assert) => {
     let count = 0;
 
     const myHelper = helper(
@@ -97,7 +97,7 @@ module('[@glimmer/core] interactive - helper', () => {
     assert.equal(count, 2, 'helper reran after positional args changed');
   });
 
-  test('custom helpers update when named args change', async assert => {
+  test('custom helpers update when named args change', async (assert) => {
     let count = 0;
 
     const myHelper = helper(
@@ -146,7 +146,7 @@ module('[@glimmer/core] interactive - helper', () => {
     assert.equal(count, 2, 'helper reran after named args changed');
   });
 
-  test('helpers are not volatile', async assert => {
+  test('helpers are not volatile', async (assert) => {
     let count = 0;
 
     function myHelper(name: string, greeting: string): string {
@@ -185,7 +185,7 @@ module('[@glimmer/core] interactive - helper', () => {
     assert.equal(count, 1, 'helper did not rerender after unrelated change');
   });
 
-  test('custom helpers lifecycle (basic)', async assert => {
+  test('custom helpers lifecycle (basic)', async (assert) => {
     let calls: string[] = [];
 
     const myHelper = helper(
@@ -257,7 +257,7 @@ module('[@glimmer/core] interactive - helper', () => {
     assert.deepEqual(calls, ['teardown'], 'teardown hook called correctly');
   });
 
-  test('update and value hook lifecycle and memoization', async assert => {
+  test('update and value hook lifecycle and memoization', async (assert) => {
     // This is necessary because we can't create and dirty tags directly because
     // that doesn't trigger `propertyDidChange` currently.
     class Tag {
@@ -363,7 +363,7 @@ module('[@glimmer/core] interactive - helper', () => {
     );
   });
 
-  test('custom helpers update when local tracked props change', async assert => {
+  test('custom helpers update when local tracked props change', async (assert) => {
     let helperInstance: MyHelper;
 
     class MyHelper {
@@ -395,7 +395,7 @@ module('[@glimmer/core] interactive - helper', () => {
     assert.strictEqual(html, '<h1>en_UK</h1>', 'the template was updated');
   });
 
-  test('custom helpers update when values on owner change', async assert => {
+  test('custom helpers update when values on owner change', async (assert) => {
     class Owner {
       services = {
         locale: new LocaleService(),

--- a/packages/@glimmer/core/test/interactive/modifier-test.ts
+++ b/packages/@glimmer/core/test/interactive/modifier-test.ts
@@ -49,10 +49,10 @@ class CustomModifierManager implements ModifierManager<CustomModifier> {
   }
 }
 
-setModifierManager(owner => new CustomModifierManager(owner), CustomModifier);
+setModifierManager((owner) => new CustomModifierManager(owner), CustomModifier);
 
 module('Modifier Tests', () => {
-  test('Supports the on modifier', async assert => {
+  test('Supports the on modifier', async (assert) => {
     class MyComponent extends Component {
       @tracked count = 0;
 
@@ -85,7 +85,7 @@ module('Modifier Tests', () => {
     );
   });
 
-  test('simple functions can be used as modifiers', async assert => {
+  test('simple functions can be used as modifiers', async (assert) => {
     function modifier(element: Element, arg1: string, arg2: number): void {
       assert.equal(element, find('h1'), 'modifier received');
       assert.equal(arg1, 'string', 'modifier received');
@@ -101,7 +101,7 @@ module('Modifier Tests', () => {
     await render(Component);
   });
 
-  test('simple function modifiers throw an error when using named arguments', async assert => {
+  test('simple function modifiers throw an error when using named arguments', async (assert) => {
     function modifier(): void {
       assert.ok(false, 'should not be called');
     }
@@ -115,12 +115,15 @@ module('Modifier Tests', () => {
     try {
       await render(Component);
     } catch (e) {
-      assert.equal(e.message, 'You used named arguments with the modifier modifier, but it is a standard function. Normal functions cannot receive named arguments when used as modifiers.', 'error thrown correctly');
+      assert.equal(
+        e.message,
+        'You used named arguments with the modifier modifier, but it is a standard function. Normal functions cannot receive named arguments when used as modifiers.',
+        'error thrown correctly'
+      );
     }
   });
 
-
-  test('simple function modifier lifecycle', async assert => {
+  test('simple function modifier lifecycle', async (assert) => {
     const hooks: string[] = [];
 
     function modifier(): () => void {
@@ -169,7 +172,7 @@ module('Modifier Tests', () => {
     );
   });
 
-  test('custom modifiers correctly receive element', async assert => {
+  test('custom modifiers correctly receive element', async (assert) => {
     assert.expect(3);
 
     class Modifier extends CustomModifier {
@@ -215,7 +218,7 @@ module('Modifier Tests', () => {
     await settled();
   });
 
-  test('custom lifecycle hooks', async assert => {
+  test('custom lifecycle hooks', async (assert) => {
     const hooks: string[] = [];
     const positionalArgs: unknown[][] = [];
     const namedArgs: Dict<unknown>[] = [];
@@ -277,7 +280,7 @@ module('Modifier Tests', () => {
     assert.deepEqual(namedArgs, [{ foo: 123 }, { foo: 456 }], 'modifier initialized correctly');
   });
 
-  test('lifecycle hooks are autotracked by default', async assert => {
+  test('lifecycle hooks are autotracked by default', async (assert) => {
     const obj = tracked({
       foo: 123,
       bar: 456,

--- a/packages/@glimmer/core/test/interactive/render-test.ts
+++ b/packages/@glimmer/core/test/interactive/render-test.ts
@@ -3,7 +3,7 @@ import { createTemplate } from '@glimmer/core';
 import { module, test, render } from '../utils';
 
 module(`[@glimmer/core] interactive rendering tests`, () => {
-  test('renders multiple components in different places', async assert => {
+  test('renders multiple components in different places', async (assert) => {
     assert.expect(2);
 
     // Note: Should try to figure out how to do this in Node so we can make this
@@ -18,7 +18,7 @@ module(`[@glimmer/core] interactive rendering tests`, () => {
     assert.equal(secondContainerElement.innerHTML, '<h1>Hello Robbie!</h1>');
   });
 
-  test('renders a component without affecting existing content', async assert => {
+  test('renders a component without affecting existing content', async (assert) => {
     assert.expect(1);
 
     // Note: Should try to figure out how to do this in Node so we can make this

--- a/packages/@glimmer/core/test/non-interactive/component-template-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/component-template-test.ts
@@ -4,14 +4,14 @@ import { getComponentTemplate, setComponentTemplate, TemplateMeta } from '../../
 import { SerializedTemplateWithLazyBlock } from '@glimmer/interfaces';
 
 class FakeTemplateMeta implements SerializedTemplateWithLazyBlock<TemplateMeta> {
-  block = "{}";
+  block = '{}';
   meta = {
-    scope: (): {} => ({})
-  }
+    scope: (): {} => ({}),
+  };
 }
 
 module('component templates', () => {
-  test('setting and getting', assert => {
+  test('setting and getting', (assert) => {
     const templateA = new FakeTemplateMeta();
     const templateAAB = new FakeTemplateMeta();
 

--- a/packages/@glimmer/core/test/non-interactive/each-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/each-test.ts
@@ -14,12 +14,12 @@ class HelloWorld extends Component {
   strings = ['Toran', 'Robert', 'Jesper'];
   frozenStrings = freeze(this.strings);
 
-  objects = this.strings.map(name => ({ name }));
+  objects = this.strings.map((name) => ({ name }));
   frozenObjects = freeze(this.objects);
 }
 
 module('[@glimmer/core] each helper', () => {
-  test('throw error if unknown special key used as key for #each', function(assert) {
+  test('throw error if unknown special key used as key for #each', function (assert) {
     const Component = class extends HelloWorld {};
 
     setComponentTemplate(
@@ -32,7 +32,7 @@ module('[@glimmer/core] each helper', () => {
     assert.rejects(render(Component), /Error: invalid keypath/);
   });
 
-  test(`renders number literals - numbers`, async function(assert) {
+  test(`renders number literals - numbers`, async function (assert) {
     assert.expect(1);
 
     const Component = class extends HelloWorld {};
@@ -47,7 +47,7 @@ module('[@glimmer/core] each helper', () => {
     assert.equal(await render(Component), '<ul><li>1</li><li>2</li><li>3</li></ul>');
   });
 
-  test(`renders number literals - frozen numbers`, async function(assert) {
+  test(`renders number literals - frozen numbers`, async function (assert) {
     assert.expect(1);
 
     const Component = class extends HelloWorld {};
@@ -62,7 +62,7 @@ module('[@glimmer/core] each helper', () => {
     assert.equal(await render(Component), '<ul><li>1</li><li>2</li><li>3</li></ul>');
   });
 
-  test(`renders string literals - strings`, async function(assert) {
+  test(`renders string literals - strings`, async function (assert) {
     assert.expect(1);
 
     const Component = class extends HelloWorld {};
@@ -77,7 +77,7 @@ module('[@glimmer/core] each helper', () => {
     assert.equal(await render(Component), '<ul><li>Toran</li><li>Robert</li><li>Jesper</li></ul>');
   });
 
-  test(`renders string literals - frozenStrings`, async function(assert) {
+  test(`renders string literals - frozenStrings`, async function (assert) {
     assert.expect(1);
 
     const Component = class extends HelloWorld {};
@@ -92,7 +92,7 @@ module('[@glimmer/core] each helper', () => {
     assert.equal(await render(Component), '<ul><li>Toran</li><li>Robert</li><li>Jesper</li></ul>');
   });
 
-  test(`renders objects - objects`, async function(assert) {
+  test(`renders objects - objects`, async function (assert) {
     assert.expect(1);
 
     const Component = class extends HelloWorld {};
@@ -107,7 +107,7 @@ module('[@glimmer/core] each helper', () => {
     assert.equal(await render(Component), '<ul><li>Toran</li><li>Robert</li><li>Jesper</li></ul>');
   });
 
-  test(`renders objects - frozenObjects`, async function(assert) {
+  test(`renders objects - frozenObjects`, async function (assert) {
     assert.expect(1);
 
     const Component = class extends HelloWorld {};

--- a/packages/@glimmer/core/test/non-interactive/helper-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/helper-test.ts
@@ -11,7 +11,7 @@ import {
 } from '@glimmer/core';
 
 module('[@glimmer/core] non-interactive - helper', () => {
-  test('simple helpers work', async assert => {
+  test('simple helpers work', async (assert) => {
     function myHelper(name: string, greeting: string): string {
       return `helper ${greeting} ${name}`;
     }
@@ -31,7 +31,7 @@ module('[@glimmer/core] non-interactive - helper', () => {
     assert.strictEqual(html, '<h1>helper Hello Rob</h1>', 'the template was rendered');
   });
 
-  test('simple helpers throw when using named args', assert => {
+  test('simple helpers throw when using named args', (assert) => {
     function myHelper(): void {
       assert.ok(false, 'helper should not be called');
     }
@@ -49,7 +49,7 @@ module('[@glimmer/core] non-interactive - helper', () => {
     );
   });
 
-  test('custom helpers work', async assert => {
+  test('custom helpers work', async (assert) => {
     const myHelper = helper(
       class {
         args: {
@@ -80,7 +80,7 @@ module('[@glimmer/core] non-interactive - helper', () => {
     assert.strictEqual(html, '<h1>helper Hello Rob</h1>', 'the template was rendered');
   });
 
-  test('custom helpers have access to host meta', async assert => {
+  test('custom helpers have access to host meta', async (assert) => {
     class Owner {
       services = {
         locale: new LocaleService(),

--- a/packages/@glimmer/core/test/non-interactive/manager-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/manager-test.ts
@@ -3,7 +3,7 @@ const { module, test } = QUnit;
 import { getComponentManager, setComponentManager } from '../../src/managers';
 
 module('component managers', () => {
-  test('setting and getting', assert => {
+  test('setting and getting', (assert) => {
     const context = {};
 
     const managerA = {} as any; // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/packages/@glimmer/core/test/non-interactive/render-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/render-test.ts
@@ -14,7 +14,7 @@ import { module, test, render } from '../utils';
 import { DEBUG } from '@glimmer/env';
 
 module(`[@glimmer/core] non-interactive rendering tests`, () => {
-  test('it renders a component', async assert => {
+  test('it renders a component', async (assert) => {
     class MyComponent extends Component {}
 
     setComponentTemplate(MyComponent, createTemplate(`<h1>Hello world</h1>`));
@@ -24,7 +24,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     assert.ok(true, 'rendered');
   });
 
-  test('a component can render a nested component', async assert => {
+  test('a component can render a nested component', async (assert) => {
     class OtherComponent extends Component {}
 
     setComponentTemplate(OtherComponent, createTemplate(`Hello world`));
@@ -40,7 +40,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     assert.ok(true, 'rendered');
   });
 
-  test('a component can render multiple nested components', async assert => {
+  test('a component can render multiple nested components', async (assert) => {
     class Foo extends Component {}
     setComponentTemplate(Foo, createTemplate(`Foo`));
 
@@ -64,7 +64,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     assert.strictEqual(html, '<h1>Hello world FooBar</h1>', 'the template was rendered');
   });
 
-  test('custom elements are rendered', async function(assert) {
+  test('custom elements are rendered', async function (assert) {
     const component = templateOnlyComponent();
 
     setComponentTemplate(component, createTemplate('<hello-world>foo</hello-world>'));
@@ -72,7 +72,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     assert.equal(await render(component), '<hello-world>foo</hello-world>');
   });
 
-  test('a component can render with args', async assert => {
+  test('a component can render with args', async (assert) => {
     class MyComponent extends Component {}
 
     setComponentTemplate(MyComponent, createTemplate('<h1>{{@say}}</h1>'));
@@ -91,7 +91,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     );
   });
 
-  test('can use block params', async function(assert) {
+  test('can use block params', async function (assert) {
     class MainComponent extends Component {
       salutation = 'Glimmer';
     }
@@ -111,8 +111,8 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     assert.equal(await render(MainComponent), 'Glimmer!');
   });
 
-  [true, false].forEach(pred => {
-    test(`can use inline if - ${pred}`, async function(assert) {
+  [true, false].forEach((pred) => {
+    test(`can use inline if - ${pred}`, async function (assert) {
       let salutationCount = 0;
       let alternativeCount = 0;
 
@@ -142,11 +142,15 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
       );
 
       assert.equal(pred ? salutationCount : alternativeCount, 1, 'chosen branch value was used');
-      assert.equal(pred ? alternativeCount : salutationCount, 0, 'non-chosen branch value was not used');
+      assert.equal(
+        pred ? alternativeCount : salutationCount,
+        0,
+        'non-chosen branch value was not used'
+      );
     });
   });
 
-  test('inline if cannot be overwritten', async function(assert) {
+  test('inline if cannot be overwritten', async function (assert) {
     class Main extends Component {
       pred = true;
       salutation = 'Glimmer';
@@ -179,7 +183,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
   //   assert.equal(await render(MainComponent), 'Hello Glimmer!');
   // });
 
-  test('components receive owner', async assert => {
+  test('components receive owner', async (assert) => {
     class Owner {
       services = {
         locale: new LocaleService(),
@@ -207,7 +211,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     assert.strictEqual(html, '<h1>en_US</h1>');
   });
 
-  test('a component can be rendered more than once', async assert => {
+  test('a component can be rendered more than once', async (assert) => {
     class MyComponent extends Component {}
 
     setComponentTemplate(MyComponent, createTemplate(`<h1>Bump</h1>`));
@@ -221,7 +225,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     assert.ok(true, 'rendered');
   });
 
-  test('a component can use modifiers', async assert => {
+  test('a component can use modifiers', async (assert) => {
     class MyComponent extends Component {
       @tracked count = 0;
 
@@ -243,7 +247,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     assert.strictEqual(html, `<button>Count: 0</button>`, 'the component was rendered');
   });
 
-  test('it can set a dynamic href on an anchor', async assert => {
+  test('it can set a dynamic href on an anchor', async (assert) => {
     class MyComponent extends Component {}
 
     setComponentTemplate(MyComponent, createTemplate(`<a href={{@href}}>Link</a>`));
@@ -252,7 +256,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     assert.strictEqual(html, '<a href="www.example.com">Link</a>', 'the template was rendered');
   });
 
-  test('it can set a dynamic src on an img', async assert => {
+  test('it can set a dynamic src on an img', async (assert) => {
     class MyComponent extends Component {}
 
     setComponentTemplate(MyComponent, createTemplate(`<img src={{@src}}/>`));
@@ -262,7 +266,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
   });
 
   if (DEBUG) {
-    test('accessing properties in template-only components produces a helpful error in development mode', async function(assert) {
+    test('accessing properties in template-only components produces a helpful error in development mode', async function (assert) {
       assert.expect(1);
 
       const component = templateOnlyComponent();
@@ -279,7 +283,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
       }
     });
   } else {
-    test('accessing properties in template-only components produces an exception in production mode', async function(assert) {
+    test('accessing properties in template-only components produces an exception in production mode', async function (assert) {
       assert.expect(1);
 
       const component = templateOnlyComponent();

--- a/packages/@glimmer/core/test/non-interactive/strict-mode-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/strict-mode-test.ts
@@ -1,16 +1,13 @@
 import Component from '@glimmer/component';
 
-import {
-  setComponentTemplate,
-  createTemplate,
-} from '@glimmer/core';
+import { setComponentTemplate, createTemplate } from '@glimmer/core';
 
 import { module, test, render } from '../utils';
 import { DEBUG } from '@glimmer/env';
 
 if (DEBUG) {
   module(`[@glimmer/core] non-interactive strict-mode tests`, () => {
-    test('throws a helpful error if upvar is used directly in a template invocation and not found in scope', async assert => {
+    test('throws a helpful error if upvar is used directly in a template invocation and not found in scope', async (assert) => {
       assert.throws(() => {
         class MyComponent extends Component {
           say = 'Hello Dolly!';
@@ -20,7 +17,7 @@ if (DEBUG) {
       }, /Error: Cannot find identifier `say` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `{{this.say}}`/);
     });
 
-    test('throws a helpful error if upvar is used as an argument and not found in scope', async assert => {
+    test('throws a helpful error if upvar is used as an argument and not found in scope', async (assert) => {
       assert.throws(() => {
         class MyComponent extends Component {
           say = 'Hello Dolly!';
@@ -30,11 +27,14 @@ if (DEBUG) {
           return param1;
         }
 
-        setComponentTemplate(MyComponent, createTemplate({ myHelper, }, '<h1>{{myHelper say}}</h1>'));
+        setComponentTemplate(
+          MyComponent,
+          createTemplate({ myHelper }, '<h1>{{myHelper say}}</h1>')
+        );
       }, /Error: Cannot find identifier `say` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `{{this.say}}`/);
     });
 
-    test('throws a helpful error if upvar is used as a helper', async assert => {
+    test('throws a helpful error if upvar is used as a helper', async (assert) => {
       assert.throws(() => {
         class MyComponent extends Component {
           say = 'Hello Dolly!';
@@ -44,7 +44,7 @@ if (DEBUG) {
       }, /Error: Cannot find identifier `say` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `{{this.say}}`/);
     });
 
-    test('throws a helpful error if upvar is used as a modifier', async assert => {
+    test('throws a helpful error if upvar is used as a modifier', async (assert) => {
       assert.throws(() => {
         class MyComponent extends Component {
           say = 'Hello Dolly!';
@@ -54,13 +54,19 @@ if (DEBUG) {
       }, /Error: Cannot find identifier `say` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `{{this.say}}`/);
     });
 
-    test('throws a helpful error if upvar is used as a component', async assert => {
+    test('throws a helpful error if upvar is used as a component', async (assert) => {
       assert.expect(1);
 
       try {
         await render(createTemplate(`<NonExistent />`));
       } catch (err) {
-        assert.ok(err.toString().match(/Cannot find component `NonExistent` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `<this.NonExistent>`/));
+        assert.ok(
+          err
+            .toString()
+            .match(
+              /Cannot find component `NonExistent` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `<this.NonExistent>`/
+            )
+        );
       }
     });
   });

--- a/packages/@glimmer/core/test/non-interactive/to-bool-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/to-bool-test.ts
@@ -5,7 +5,7 @@ import { setComponentTemplate, createTemplate } from '@glimmer/core';
 import { module, test, render } from '../utils';
 
 module(`[@glimmer/core] non-interactive rendering tests`, () => {
-  test(`normal if treats empty arrays as falsy`, async function(assert) {
+  test(`normal if treats empty arrays as falsy`, async function (assert) {
     class Main extends Component {
       pred = [];
       salutation = 'Glimmer';
@@ -20,7 +20,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     assert.equal(await render(Main), `Hello Glimmer.js!`, 'output is correct');
   });
 
-  test(`inline if treats empty arrays as falsy`, async function(assert) {
+  test(`inline if treats empty arrays as falsy`, async function (assert) {
     class Main extends Component {
       pred = [];
     }

--- a/packages/@glimmer/core/test/utils.ts
+++ b/packages/@glimmer/core/test/utils.ts
@@ -61,15 +61,9 @@ export async function settled(): Promise<string> {
   return document.getElementById('qunit-fixture')!.innerHTML;
 }
 
-export function tracked<T extends object>(
-  obj: T | typeof Object
-): T;
+export function tracked<T extends object>(obj: T | typeof Object): T;
 
-export function tracked(
-  obj: object,
-  key: string | symbol,
-  desc?: PropertyDescriptor
-): void;
+export function tracked(obj: object, key: string | symbol, desc?: PropertyDescriptor): void;
 
 export function tracked(
   obj: object,

--- a/packages/@glimmer/core/test/utils/custom-helper.ts
+++ b/packages/@glimmer/core/test/utils/custom-helper.ts
@@ -55,9 +55,10 @@ class CustomHelperManager implements HelperManager<Helper> {
   }
 }
 
-const CustomHelperManagerFactory = (owner: unknown): CustomHelperManager => new CustomHelperManager(owner);
+const CustomHelperManagerFactory = (owner: unknown): CustomHelperManager =>
+  new CustomHelperManager(owner);
 
 export function helper(Class: HelperConstructor): HelperConstructor {
   setHelperManager(CustomHelperManagerFactory, Class);
   return Class;
-};
+}

--- a/packages/@glimmer/core/test/utils/tracked-object.d.ts
+++ b/packages/@glimmer/core/test/utils/tracked-object.d.ts
@@ -1,7 +1,7 @@
 declare interface TrackedObject {
-  fromEntries<T = unknown>(entries: Iterable<readonly [PropertyKey, T]>): { [k in PropertyKey]: T }
+  fromEntries<T = unknown>(entries: Iterable<readonly [PropertyKey, T]>): { [k in PropertyKey]: T };
 
-  new<T = {}>(obj?: T): T;
+  new <T = {}>(obj?: T): T;
 }
 
 declare const TrackedObject: TrackedObject;

--- a/packages/@glimmer/core/test/utils/tracked-object.js
+++ b/packages/@glimmer/core/test/utils/tracked-object.js
@@ -3,7 +3,6 @@ import { consumeTag, tagFor, dirtyTagFor } from '@glimmer/validator';
 const COLLECTION = Symbol();
 
 function createProxy(obj = {}) {
-
   return new Proxy(obj, {
     get(target, prop) {
       consumeTag(tagFor(target, prop));
@@ -45,7 +44,7 @@ export default class TrackedObject {
 
   constructor(obj = {}) {
     let proto = Object.getPrototypeOf(obj);
-    let descs = Object.getOwnPropertyDescriptors(obj)
+    let descs = Object.getOwnPropertyDescriptors(obj);
 
     let clone = Object.create(proto);
 

--- a/packages/@glimmer/helper/src/fn.ts
+++ b/packages/@glimmer/helper/src/fn.ts
@@ -5,7 +5,10 @@ import { assert } from '@glimmer/util';
 export default function fn(fn: (...args: unknown[]) => unknown, ...args: unknown[]) {
   if (DEBUG) {
     assert(typeof fn === 'function', 'fn must receive a function as its first parameter');
-    assert(args.length > 0, 'fn must receive at least one argument to pass to the function, otherwise there is no need to use fn.');
+    assert(
+      args.length > 0,
+      'fn must receive at least one argument to pass to the function, otherwise there is no need to use fn.'
+    );
   }
   return fn.bind(null, ...args);
 }

--- a/packages/@glimmer/ssr/src/render.ts
+++ b/packages/@glimmer/ssr/src/render.ts
@@ -9,7 +9,6 @@ import { BaseEnvDelegate } from '@glimmer/core';
 import { NodeDOMTreeConstruction } from '@glimmer/node';
 import { DOMChanges } from '@glimmer/runtime';
 
-
 /**
  * Server-side environment that can be used to configure the glimmer-vm to work
  * on the server side.
@@ -28,7 +27,7 @@ class ServerEnvDelegate extends BaseEnvDelegate {
 export interface RenderOptions {
   args?: Dict<unknown>;
   serializer?: HTMLSerializer;
-  owner?: object
+  owner?: object;
 }
 
 const defaultSerializer = new HTMLSerializer(voidMap);
@@ -41,9 +40,9 @@ export function renderToString(
     const stream = new PassThrough();
     let html = '';
 
-    stream.on('data', str => (html += str));
+    stream.on('data', (str) => (html += str));
     stream.on('end', () => resolve(html));
-    stream.on('error', err => reject(err));
+    stream.on('error', (err) => reject(err));
 
     renderToStream(stream, ComponentClass, options);
   });

--- a/packages/@glimmer/ssr/test/modifiers-test.ts
+++ b/packages/@glimmer/ssr/test/modifiers-test.ts
@@ -33,10 +33,10 @@ class CustomModifierManager implements ModifierManager<CustomModifier> {
   destroyModifier(): void {}
 }
 
-setModifierManager(owner => new CustomModifierManager(owner), CustomModifier);
+setModifierManager((owner) => new CustomModifierManager(owner), CustomModifier);
 
 QUnit.module('@glimmer/ssr modifiers', () => {
-  QUnit.test('modifiers do not run in SSR', async assert => {
+  QUnit.test('modifiers do not run in SSR', async (assert) => {
     class Modifier extends CustomModifier {
       didInsertElement(): void {
         assert.ok(false, 'modifiers should not trigger insert in SSR');

--- a/packages/@glimmer/ssr/test/render-options-tests.ts
+++ b/packages/@glimmer/ssr/test/render-options-tests.ts
@@ -6,7 +6,7 @@ import { SerializableNode } from '@simple-dom/interface';
 import { renderToString, RenderOptions } from '..';
 
 QUnit.module('@glimmer/ssr rendering', () => {
-  QUnit.test('options.serializer', async assert => {
+  QUnit.test('options.serializer', async (assert) => {
     class MyComponent extends Component {}
 
     class CustomHTMLSerializer extends HTMLSerializer {

--- a/packages/@glimmer/tracking/src/tracked.ts
+++ b/packages/@glimmer/tracking/src/tracked.ts
@@ -85,7 +85,7 @@ function throwTrackedWithArgumentsError(args: unknown[]): never {
     `You attempted to use @tracked with ${
       args.length > 1 ? 'arguments' : 'an argument'
     } ( @tracked(${args
-      .map(d => `'${d}'`)
+      .map((d) => `'${d}'`)
       .join(
         ', '
       )}) ), which is no longer necessary nor supported. Dependencies are now automatically tracked, so you can just use ${'`@tracked`'}.`

--- a/packages/@glimmer/tracking/test/tracked-decorator-test.ts
+++ b/packages/@glimmer/tracking/test/tracked-decorator-test.ts
@@ -16,14 +16,14 @@ import { assertValidAfterUnrelatedBump } from './helpers/tags';
 ].forEach(([compiler, F]) => {
   module(`[@glimmer/tracking] Tracked Property Decorators with ${compiler}`);
 
-  test('tracked properties can be read and written to', assert => {
+  test('tracked properties can be read and written to', (assert) => {
     const obj = new F.Tom();
     assert.strictEqual(obj.firstName, 'Tom');
     obj.firstName = 'Edsger';
     assert.strictEqual(obj.firstName, 'Edsger');
   });
 
-  test('can request a tag for a property', assert => {
+  test('can request a tag for a property', (assert) => {
     const obj = new F.Tom();
     assert.strictEqual(obj.firstName, 'Tom');
 
@@ -34,14 +34,18 @@ import { assertValidAfterUnrelatedBump } from './helpers/tags';
     assert.ok(validateTag(tag, snapshot), 'tag should be valid to start');
 
     obj.firstName = 'Edsger';
-    assert.strictEqual(validateTag(tag, snapshot), false, 'tag is invalidated after property is set');
+    assert.strictEqual(
+      validateTag(tag, snapshot),
+      false,
+      'tag is invalidated after property is set'
+    );
     snapshot = valueForTag(tag);
     assert.strictEqual(validateTag(tag, snapshot), true, 'tag is valid on the second check');
 
     assertValidAfterUnrelatedBump(tag, snapshot);
   });
 
-  test('can request a tag from a frozen class instance', assert => {
+  test('can request a tag from a frozen class instance', (assert) => {
     const obj = Object.freeze(new F.Toran());
     assert.strictEqual(obj.firstName, 'Toran');
     assert.strictEqual(obj.lastName, 'Billups');
@@ -67,7 +71,7 @@ import { assertValidAfterUnrelatedBump } from './helpers/tags';
     assertValidAfterUnrelatedBump(tag, snapshot);
   });
 
-  test('can request a tag from an instance of a frozen class', assert => {
+  test('can request a tag from an instance of a frozen class', (assert) => {
     const obj = Object.freeze(new F.FrozenToran());
 
     assert.strictEqual(obj.firstName, 'Toran');
@@ -83,7 +87,7 @@ import { assertValidAfterUnrelatedBump } from './helpers/tags';
     assertValidAfterUnrelatedBump(tag, snapshot);
   });
 
-  test('can track a getter', assert => {
+  test('can track a getter', (assert) => {
     const obj = new F.PersonWithCount();
     assert.strictEqual(obj.firstName, 'Tom0');
     assert.strictEqual(obj.firstName, 'Tom1');
@@ -98,13 +102,17 @@ import { assertValidAfterUnrelatedBump } from './helpers/tags';
     assert.ok(validateTag(tag, snapshot), 'reading from property does not invalidate the tag');
 
     obj.firstName = 'Edsger';
-    assert.strictEqual(validateTag(tag, snapshot), false, 'tag is invalidated after property is set');
+    assert.strictEqual(
+      validateTag(tag, snapshot),
+      false,
+      'tag is invalidated after property is set'
+    );
     snapshot = valueForTag(tag);
 
     assertValidAfterUnrelatedBump(tag, snapshot);
   });
 
-  test('getters are invalidated when their dependencies are invalidated', assert => {
+  test('getters are invalidated when their dependencies are invalidated', (assert) => {
     const obj = new F.PersonWithSalutation();
     assert.strictEqual(obj.salutation, 'Hello, Tom Dale!', `the saluation field is valid`);
     assert.strictEqual(obj.fullName, 'Tom Dale', `the fullName field is valid`);
@@ -145,7 +153,7 @@ import { assertValidAfterUnrelatedBump } from './helpers/tags';
     assertValidAfterUnrelatedBump(tag, snapshot);
   });
 
-  test('nested @tracked in multiple objects', assert => {
+  test('nested @tracked in multiple objects', (assert) => {
     const obj = new F.Contact(new F.PersonForContact(), 'tom@example.com');
     assert.strictEqual(obj.contact, 'Tom Dale @ tom@example.com', `the contact field is valid`);
     assert.strictEqual(obj.person.fullName, 'Tom Dale', `the fullName field is valid`);
@@ -202,15 +210,15 @@ import { assertValidAfterUnrelatedBump } from './helpers/tags';
   });
 
   if (DEBUG) {
-    test('Tracked decorator with a getter throws an error', assert => {
+    test('Tracked decorator with a getter throws an error', (assert) => {
       assert.throws(F.createClassWithTrackedGetter);
     });
 
-    test('Tracked decorator with a setter throws an error', assert => {
+    test('Tracked decorator with a setter throws an error', (assert) => {
       assert.throws(F.createClassWithTrackedSetter);
     });
 
-    test('Tracked decorator with arguments throws an error', function(assert) {
+    test('Tracked decorator with arguments throws an error', function (assert) {
       assert.throws(
         F.createClassWithTrackedDependentKeys,
         /@tracked\('firstName', 'lastName'\)/,
@@ -218,7 +226,7 @@ import { assertValidAfterUnrelatedBump } from './helpers/tags';
       );
     });
 
-    test('Using @tracked as a decorator factory throws an error', function(assert) {
+    test('Using @tracked as a decorator factory throws an error', function (assert) {
       assert.throws(
         F.createClassWithTrackedAsDecoratorFactory,
         /@tracked\(\)/,

--- a/packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/index.js
+++ b/packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/index.js
@@ -95,7 +95,7 @@ function _precompileTemplate(parse, templateString, scopeNode, precompileOptions
 
   let metaSeen = false;
 
-  t.traverseFast(ast, node => {
+  t.traverseFast(ast, (node) => {
     if (t.isObjectProperty(node)) {
       if (node.key.value === 'meta') {
         metaSeen = true;
@@ -109,9 +109,10 @@ function _precompileTemplate(parse, templateString, scopeNode, precompileOptions
 
   if (metaSeen === false) {
     ast.program.body[0].expression.properties.push(
-      t.objectProperty(t.identifier('meta'), t.objectExpression([
-        t.objectProperty(t.identifier('scope'), scopeNode)
-      ]))
+      t.objectProperty(
+        t.identifier('meta'),
+        t.objectExpression([t.objectProperty(t.identifier('scope'), scopeNode)])
+      )
     );
   }
 
@@ -132,7 +133,7 @@ function precompileTemplate(templateString, importIdentifiers = [], precompileOp
   const scope = t.arrowFunctionExpression(
     [],
     t.objectExpression(
-      importIdentifiers.map(id => t.objectProperty(t.identifier(id), t.identifier(id)))
+      importIdentifiers.map((id) => t.objectProperty(t.identifier(id), t.identifier(id)))
     )
   );
 

--- a/packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/test/index.js
+++ b/packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/test/index.js
@@ -53,7 +53,11 @@ describe('precompileTemplate', () => {
   });
 
   it('can apply precompile transforms', () => {
-    let precompiled = precompileTemplate('{{bad}}<h1>Hello world</h1>', [], astTransformTestPluginOptions.precompile);
+    let precompiled = precompileTemplate(
+      '{{bad}}<h1>Hello world</h1>',
+      [],
+      astTransformTestPluginOptions.precompile
+    );
 
     expect(precompiled).to.equal(`({
   id: "k5+y7pkD",

--- a/packages/example-apps/basic/src/MyComponent.ts
+++ b/packages/example-apps/basic/src/MyComponent.ts
@@ -11,11 +11,11 @@ import OtherComponent from './OtherComponent';
 import { on, action } from '@glimmer/modifier';
 import { Owner } from '..';
 
-const myHelper = helper(function([name], { greeting }) {
+const myHelper = helper(function ([name], { greeting }) {
   return `Helper: ${greeting} ${name}`;
 });
 
-const isCJK = helper(function(_args, _hash, services) {
+const isCJK = helper(function (_args, _hash, services) {
   const localeService = services.locale as LocaleService;
   return (
     localeService.currentLocale === 'zh_CN' ||

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,10 +24,7 @@ module.exports = {
               ['@babel/plugin-proposal-decorators', { legacy: true }],
               '@babel/plugin-proposal-class-properties',
             ],
-            presets: [
-              '@babel/preset-typescript',
-              '@babel/preset-env',
-            ],
+            presets: ['@babel/preset-typescript', '@babel/preset-env'],
           },
         },
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10194,10 +10194,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
+  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
 
 printf@^0.5.1:
   version "0.5.2"


### PR DESCRIPTION
* Updates to prettier@ (see [blog post](https://prettier.io/blog/2020/03/21/2.0.0.html) for details).
* Fix issue with prettier linting setup (prettier was not being enforced by `eslint` prior to these changes).
* Run `yarn lint --fix` to fix all the files.

This will be easiest to review by looking at the first commit on its own, as the second commit is `eslint --fix .` basically.