### PR TITLE
Add prettier to generated project's package.json.

### DIFF
--- a/packages/@glimmer/blueprint/files/package.json
+++ b/packages/@glimmer/blueprint/files/package.json
@@ -40,6 +40,7 @@
     "file-loader": "^6.0.0",
     "glob": "7.1.6",
     "html-webpack-plugin": "^4.0.4",
+    "prettier": "^2.0.2",
     "qunit": "^2.9.3",
     "qunit-dom": "^1.1.0",
     "style-loader": "^1.1.3",


### PR DESCRIPTION
The linting configuration leveraged `prettier`, but did not actually install it.