### PR TITLE
Update release-it-yarn-workspaces to 1.3.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "qunit": "^2.9.3",
     "release-it": "^13.5.1",
     "release-it-lerna-changelog": "^2.1.2",
-    "release-it-yarn-workspaces": "^1.2.0",
+    "release-it-yarn-workspaces": "^1.3.0",
     "rimraf": "^3.0.2",
     "semver": "^7.1.3",
     "testem": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10705,10 +10705,10 @@ release-it-lerna-changelog@^2.1.2:
     release-it "^13.3.2"
     tmp "^0.1.0"
 
-release-it-yarn-workspaces@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/release-it-yarn-workspaces/-/release-it-yarn-workspaces-1.2.0.tgz#b7a3fc8c587c4e60679d9efe21d2072d85694d20"
-  integrity sha512-QXTtDBQS8KAE3pHRQ4yG0PccuN/+5UBKzn7zzj0aMOmcmJe6fsZR3RnCuhHRo+GbXMDWtFo69Yf3NANWSiT2ew==
+release-it-yarn-workspaces@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/release-it-yarn-workspaces/-/release-it-yarn-workspaces-1.3.0.tgz#942bb7874f2822316789b2b25468b52ce78ae4c2"
+  integrity sha512-UT1q1kqzwo7RlcOifMy25ztwpl3Kmf4xyvzSd8zeiqVeqIFNIb4QBDqmW1N+VS2QCxViJw3tVxusu4t3cl1T+w==
   dependencies:
     detect-indent "^6.0.0"
     detect-newline "^3.1.0"


### PR DESCRIPTION
Fixes a few minor things (adds some features we don't need here), but also dramatically improves the `--dry-run` output.

https://github.com/rwjblue/release-it-yarn-workspaces/releases/tag/v1.3.0