### PR TITLE
[BUGFIX][BREAKING] Fixes setComponentTemplate

### DIFF
--- a/packages/@glimmer/blueprint/files/src/App.js
+++ b/packages/@glimmer/blueprint/files/src/App.js
@@ -9,7 +9,6 @@ export default class App extends Component {
 }
 
 setComponentTemplate(
-  App,
   createTemplate(`
     <div id="intro">
       <img src={{this.logo}}/>
@@ -20,5 +19,6 @@ setComponentTemplate(
         and run tests by visiting <a href="./tests">/tests</a>
       </h3>
     </div>
-  `)
+  `),
+  App
 );

--- a/packages/@glimmer/component/test/interactive/args-test.ts
+++ b/packages/@glimmer/component/test/interactive/args-test.ts
@@ -27,14 +27,14 @@ module('[@glimmer/component] Component Arguments', () => {
     }
 
     setComponentTemplate(
-      ParentComponent,
       createTemplate(
         { ChildComponent },
         '<ChildComponent @firstName={{this.firstName}} @status={{this.status}} />'
-      )
+      ),
+      ParentComponent
     );
 
-    setComponentTemplate(ChildComponent, createTemplate('{{this.name}} {{@status}}'));
+    setComponentTemplate(createTemplate('{{this.name}} {{@status}}'), ChildComponent);
 
     assert.equal(await render(ParentComponent), 'Tom Dale is dope');
 

--- a/packages/@glimmer/component/test/interactive/lifecycle-hook-test.ts
+++ b/packages/@glimmer/component/test/interactive/lifecycle-hook-test.ts
@@ -37,7 +37,6 @@ module('[@glimmer/component] Lifecycle Hooks', () => {
     class Component5 extends HookLoggerComponent {}
 
     setComponentTemplate(
-      Component1,
       createTemplate(
         { Component2, Component3 },
         `
@@ -46,11 +45,11 @@ module('[@glimmer/component] Lifecycle Hooks', () => {
             <Component3 @name="component3"/>
           {{/if}}
         `
-      )
+      ),
+      Component1
     );
 
     setComponentTemplate(
-      Component2,
       createTemplate(
         { Component4, Component5 },
         `
@@ -58,14 +57,15 @@ module('[@glimmer/component] Lifecycle Hooks', () => {
           <Component4 @name="component4"/>
           <Component5 @name="component5"/>
         `
-      )
+      ),
+      Component2
     );
 
     const emptyTemplate = createTemplate('');
 
-    setComponentTemplate(Component3, emptyTemplate);
-    setComponentTemplate(Component4, emptyTemplate);
-    setComponentTemplate(Component5, emptyTemplate);
+    setComponentTemplate(emptyTemplate, Component3);
+    setComponentTemplate(emptyTemplate, Component4);
+    setComponentTemplate(emptyTemplate, Component5);
 
     await render(Component1, { args: { name: 'component1' } });
 

--- a/packages/@glimmer/core/src/template.ts
+++ b/packages/@glimmer/core/src/template.ts
@@ -28,8 +28,8 @@ const builtInHelpers = {
 };
 
 export function setComponentTemplate<T extends object>(
-  ComponentClass: T,
-  template: SerializedTemplateWithLazyBlock<TemplateMeta>
+  template: SerializedTemplateWithLazyBlock<TemplateMeta>,
+  ComponentClass: T
 ): T {
   if (DEBUG) {
     const scope = template.meta.scope();

--- a/packages/@glimmer/core/test/interactive/fn-test.ts
+++ b/packages/@glimmer/core/test/interactive/fn-test.ts
@@ -32,11 +32,11 @@ module('[@glimmer/core] interactive - {{fn}}', () => {
     }
 
     setComponentTemplate(
-      HelloWorld,
       createTemplate(
         { on, fn },
         '<button {{on "click" (fn this.userDidClick "hello" this.name)}}>Hello World</button>'
-      )
+      ),
+      HelloWorld
     );
 
     const output = await render(HelloWorld);
@@ -84,27 +84,25 @@ module('[@glimmer/core] interactive - {{fn}}', () => {
       }
     }
 
-    const Grandchild = templateOnlyComponent();
-    setComponentTemplate(
-      Grandchild,
-      createTemplate({ on, fn }, '<button {{on "click" (fn @userDidClick 5 6)}}></button>')
+    const Grandchild = setComponentTemplate(
+      createTemplate({ on, fn }, '<button {{on "click" (fn @userDidClick 5 6)}}></button>'),
+      templateOnlyComponent()
     );
 
-    const Child = templateOnlyComponent();
-    setComponentTemplate(
-      Child,
+    const Child = setComponentTemplate(
       createTemplate(
         { Grandchild, fn },
         '<div><Grandchild @userDidClick={{fn @userDidClick 3 4}} /></div>'
-      )
+      ),
+      templateOnlyComponent()
     );
 
     setComponentTemplate(
-      ParentComponent,
       createTemplate(
         { Child, fn },
         '<div><Child @userDidClick={{fn this.userDidClick 1 2}} /></div>'
-      )
+      ),
+      ParentComponent
     );
 
     await render(ParentComponent);
@@ -121,8 +119,8 @@ module('[@glimmer/core] interactive - {{fn}}', () => {
     class Parent extends Component {}
 
     setComponentTemplate(
-      Parent,
-      createTemplate({ on, fn }, '<button {{on "click" (fn this.doesntExist)}}></button>')
+      createTemplate({ on, fn }, '<button {{on "click" (fn this.doesntExist)}}></button>'),
+      Parent
     );
 
     assert.rejects(render(Parent), /fn must receive a function as its first parameter/);
@@ -137,8 +135,8 @@ module('[@glimmer/core] interactive - {{fn}}', () => {
     }
 
     setComponentTemplate(
-      Parent,
-      createTemplate({ on, fn }, '<button {{on "click" (fn this.exists)}}></button>')
+      createTemplate({ on, fn }, '<button {{on "click" (fn this.exists)}}></button>'),
+      Parent
     );
 
     assert.rejects(

--- a/packages/@glimmer/core/test/interactive/helper-test.ts
+++ b/packages/@glimmer/core/test/interactive/helper-test.ts
@@ -3,10 +3,10 @@ import { module, test, render, settled } from '../utils';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import {
-  templateOnlyComponent,
   setComponentTemplate,
   createTemplate,
   getOwner,
+  templateOnlyComponent,
 } from '@glimmer/core';
 import { helper } from '../utils/custom-helper';
 
@@ -31,8 +31,8 @@ module('[@glimmer/core] interactive - helper', () => {
     }
 
     setComponentTemplate(
-      MyComponent,
-      createTemplate({ myHelper }, '<h1>{{myHelper this.name "Hello"}}</h1>')
+      createTemplate({ myHelper }, '<h1>{{myHelper this.name "Hello"}}</h1>'),
+      MyComponent
     );
 
     let html = await render(MyComponent);
@@ -80,8 +80,8 @@ module('[@glimmer/core] interactive - helper', () => {
     }
 
     setComponentTemplate(
-      MyComponent,
-      createTemplate({ myHelper }, '<h1>{{myHelper this.name greeting=this.greeting}}</h1>')
+      createTemplate({ myHelper }, '<h1>{{myHelper this.name greeting=this.greeting}}</h1>'),
+      MyComponent
     );
 
     let html = await render(MyComponent);
@@ -129,8 +129,8 @@ module('[@glimmer/core] interactive - helper', () => {
     }
 
     setComponentTemplate(
-      MyComponent,
-      createTemplate({ myHelper }, '<h1>{{myHelper this.name greeting=this.greeting}}</h1>')
+      createTemplate({ myHelper }, '<h1>{{myHelper this.name greeting=this.greeting}}</h1>'),
+      MyComponent
     );
 
     let html = await render(MyComponent);
@@ -168,8 +168,8 @@ module('[@glimmer/core] interactive - helper', () => {
     }
 
     setComponentTemplate(
-      MyComponent,
-      createTemplate({ myHelper }, '<h1>{{myHelper this.name "Hello"}}</h1>')
+      createTemplate({ myHelper }, '<h1>{{myHelper this.name "Hello"}}</h1>'),
+      MyComponent
     );
 
     let html = await render(MyComponent);
@@ -230,11 +230,11 @@ module('[@glimmer/core] interactive - helper', () => {
     }
 
     setComponentTemplate(
-      MyComponent,
       createTemplate(
         { myHelper },
         '{{#if this.cond}}{{myHelper this.name greeting="Hello"}}{{/if}}'
-      )
+      ),
+      MyComponent
     );
 
     let html = await render(MyComponent);
@@ -306,9 +306,10 @@ module('[@glimmer/core] interactive - helper', () => {
       }
     );
 
-    const MyComponent = templateOnlyComponent();
-
-    setComponentTemplate(MyComponent, createTemplate({ myHelper }, '{{myHelper}}'));
+    const MyComponent = setComponentTemplate(
+      createTemplate({ myHelper }, '{{myHelper}}'),
+      templateOnlyComponent()
+    );
 
     let html = await render(MyComponent);
 
@@ -380,9 +381,10 @@ module('[@glimmer/core] interactive - helper', () => {
 
     const myHelper = helper(MyHelper);
 
-    const MyComponent = templateOnlyComponent();
-
-    setComponentTemplate(MyComponent, createTemplate({ myHelper }, '<h1>{{myHelper}}</h1>'));
+    const MyComponent = setComponentTemplate(
+      createTemplate({ myHelper }, '<h1>{{myHelper}}</h1>'),
+      templateOnlyComponent()
+    );
 
     let html = await render(MyComponent);
 
@@ -414,9 +416,10 @@ module('[@glimmer/core] interactive - helper', () => {
       }
     );
 
-    const MyComponent = templateOnlyComponent();
-
-    setComponentTemplate(MyComponent, createTemplate({ myHelper }, '<h1>{{myHelper}}</h1>'));
+    const MyComponent = setComponentTemplate(
+      createTemplate({ myHelper }, '<h1>{{myHelper}}</h1>'),
+      templateOnlyComponent()
+    );
 
     const owner = new Owner();
 

--- a/packages/@glimmer/core/test/interactive/modifier-test.ts
+++ b/packages/@glimmer/core/test/interactive/modifier-test.ts
@@ -6,11 +6,11 @@ import Component from '@glimmer/component';
 import {
   setComponentTemplate,
   createTemplate,
-  templateOnlyComponent,
   modifierCapabilities,
   TemplateArgs,
   setModifierManager,
   ModifierManager,
+  templateOnlyComponent,
 } from '@glimmer/core';
 import { Dict } from '@glimmer/interfaces';
 
@@ -63,11 +63,11 @@ module('Modifier Tests', () => {
     }
 
     setComponentTemplate(
-      MyComponent,
       createTemplate(
         { on },
         `<button {{on "click" this.incrementCounter}}>Count: {{this.count}}</button>`
-      )
+      ),
+      MyComponent
     );
 
     assert.strictEqual(
@@ -92,10 +92,9 @@ module('Modifier Tests', () => {
       assert.equal(arg2, 123, 'modifier received');
     }
 
-    const Component = templateOnlyComponent();
-    setComponentTemplate(
-      Component,
-      createTemplate({ modifier }, '<h1 {{modifier "string" 123}}>hello world</h1>')
+    const Component = setComponentTemplate(
+      createTemplate({ modifier }, '<h1 {{modifier "string" 123}}>hello world</h1>'),
+      templateOnlyComponent()
     );
 
     await render(Component);
@@ -106,10 +105,9 @@ module('Modifier Tests', () => {
       assert.ok(false, 'should not be called');
     }
 
-    const Component = templateOnlyComponent();
-    setComponentTemplate(
-      Component,
-      createTemplate({ modifier }, '<h1 {{modifier named=456}}>hello world</h1>')
+    const Component = setComponentTemplate(
+      createTemplate({ modifier }, '<h1 {{modifier named=456}}>hello world</h1>'),
+      templateOnlyComponent()
     );
 
     try {
@@ -134,10 +132,12 @@ module('Modifier Tests', () => {
       };
     }
 
-    const Component = templateOnlyComponent();
-    setComponentTemplate(
-      Component,
-      createTemplate({ modifier }, '{{#if @truthy}}<h1 {{modifier @value}}>hello world</h1>{{/if}}')
+    const Component = setComponentTemplate(
+      createTemplate(
+        { modifier },
+        '{{#if @truthy}}<h1 {{modifier @value}}>hello world</h1>{{/if}}'
+      ),
+      templateOnlyComponent()
     );
 
     await render(Component);
@@ -193,13 +193,12 @@ module('Modifier Tests', () => {
       }
     }
 
-    const Component = templateOnlyComponent();
-    setComponentTemplate(
-      Component,
+    const Component = setComponentTemplate(
       createTemplate(
         { modifier: Modifier },
         '{{#if @truthy}}<h1 {{modifier @value foo=@value}}>hello world</h1>{{/if}}'
-      )
+      ),
+      templateOnlyComponent()
     );
 
     const args = tracked({
@@ -241,13 +240,12 @@ module('Modifier Tests', () => {
       }
     }
 
-    const Component = templateOnlyComponent();
-    setComponentTemplate(
-      Component,
+    const Component = setComponentTemplate(
       createTemplate(
         { modifier: Modifier },
         '{{#if @truthy}}<h1 {{modifier @value foo=@value}}>hello world</h1>{{/if}}'
-      )
+      ),
+      templateOnlyComponent()
     );
 
     const args = tracked({
@@ -302,10 +300,9 @@ module('Modifier Tests', () => {
       }
     }
 
-    const Component = templateOnlyComponent();
-    setComponentTemplate(
-      Component,
-      createTemplate({ modifier: Modifier }, '<h1 {{modifier}}>hello world</h1>')
+    const Component = setComponentTemplate(
+      createTemplate({ modifier: Modifier }, '<h1 {{modifier}}>hello world</h1>'),
+      templateOnlyComponent()
     );
 
     const html = await render(Component);

--- a/packages/@glimmer/core/test/non-interactive/component-template-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/component-template-test.ts
@@ -16,12 +16,12 @@ module('component templates', () => {
     const templateAAB = new FakeTemplateMeta();
 
     class A {}
-    setComponentTemplate(A, templateA);
+    setComponentTemplate(templateA, A);
     class AA extends A {}
     class AB extends A {}
     class AAA extends AA {}
     class AAB extends AA {}
-    setComponentTemplate(AAB, templateAAB);
+    setComponentTemplate(templateAAB, AAB);
 
     class B {}
     class BA {}

--- a/packages/@glimmer/core/test/non-interactive/each-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/each-test.ts
@@ -23,10 +23,10 @@ module('[@glimmer/core] each helper', () => {
     const Component = class extends HelloWorld {};
 
     setComponentTemplate(
-      Component,
       createTemplate(
         `<ul>{{#each this.strings key="@unknown" as |item|}}<li>{{item}}</li>{{/each}}</ul>`
-      )
+      ),
+      Component
     );
 
     assert.rejects(render(Component), /Error: invalid keypath/);
@@ -38,10 +38,10 @@ module('[@glimmer/core] each helper', () => {
     const Component = class extends HelloWorld {};
 
     setComponentTemplate(
-      Component,
       createTemplate(
         `<ul>{{#each this.numbers key="@index" as |item|}}<li>{{item}}</li>{{/each}}</ul>`
-      )
+      ),
+      Component
     );
 
     assert.equal(await render(Component), '<ul><li>1</li><li>2</li><li>3</li></ul>');
@@ -53,10 +53,10 @@ module('[@glimmer/core] each helper', () => {
     const Component = class extends HelloWorld {};
 
     setComponentTemplate(
-      Component,
       createTemplate(
         `<ul>{{#each this.frozenNumbers key="@index" as |item|}}<li>{{item}}</li>{{/each}}</ul>`
-      )
+      ),
+      Component
     );
 
     assert.equal(await render(Component), '<ul><li>1</li><li>2</li><li>3</li></ul>');
@@ -68,10 +68,10 @@ module('[@glimmer/core] each helper', () => {
     const Component = class extends HelloWorld {};
 
     setComponentTemplate(
-      Component,
       createTemplate(
         `<ul>{{#each this.strings key="@index" as |item|}}<li>{{item}}</li>{{/each}}</ul>`
-      )
+      ),
+      Component
     );
 
     assert.equal(await render(Component), '<ul><li>Toran</li><li>Robert</li><li>Jesper</li></ul>');
@@ -83,10 +83,10 @@ module('[@glimmer/core] each helper', () => {
     const Component = class extends HelloWorld {};
 
     setComponentTemplate(
-      Component,
       createTemplate(
         `<ul>{{#each this.frozenStrings key="@index" as |item|}}<li>{{item}}</li>{{/each}}</ul>`
-      )
+      ),
+      Component
     );
 
     assert.equal(await render(Component), '<ul><li>Toran</li><li>Robert</li><li>Jesper</li></ul>');
@@ -98,10 +98,10 @@ module('[@glimmer/core] each helper', () => {
     const Component = class extends HelloWorld {};
 
     setComponentTemplate(
-      Component,
       createTemplate(
         `<ul>{{#each this.objects key="@index" as |item|}}<li>{{item.name}}</li>{{/each}}</ul>`
-      )
+      ),
+      Component
     );
 
     assert.equal(await render(Component), '<ul><li>Toran</li><li>Robert</li><li>Jesper</li></ul>');
@@ -113,10 +113,10 @@ module('[@glimmer/core] each helper', () => {
     const Component = class extends HelloWorld {};
 
     setComponentTemplate(
-      Component,
       createTemplate(
         `<ul>{{#each this.frozenObjects key="@index" as |item|}}<li>{{item.name}}</li>{{/each}}</ul>`
-      )
+      ),
+      Component
     );
 
     assert.equal(await render(Component), '<ul><li>Toran</li><li>Robert</li><li>Jesper</li></ul>');

--- a/packages/@glimmer/core/test/non-interactive/helper-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/helper-test.ts
@@ -4,10 +4,10 @@ import { helper } from '../utils/custom-helper';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import {
-  templateOnlyComponent,
   setComponentTemplate,
   createTemplate,
   getOwner,
+  templateOnlyComponent,
 } from '@glimmer/core';
 
 module('[@glimmer/core] non-interactive - helper', () => {
@@ -22,8 +22,8 @@ module('[@glimmer/core] non-interactive - helper', () => {
     }
 
     setComponentTemplate(
-      MyComponent,
-      createTemplate({ myHelper }, '<h1>{{myHelper this.name "Hello"}}</h1>')
+      createTemplate({ myHelper }, '<h1>{{myHelper this.name "Hello"}}</h1>'),
+      MyComponent
     );
 
     const html = await render(MyComponent);
@@ -39,8 +39,8 @@ module('[@glimmer/core] non-interactive - helper', () => {
     class MyComponent extends Component {}
 
     setComponentTemplate(
-      MyComponent,
-      createTemplate({ myHelper }, '<h1>{{myHelper this.name greeting="Hello"}}</h1>')
+      createTemplate({ myHelper }, '<h1>{{myHelper this.name greeting="Hello"}}</h1>'),
+      MyComponent
     );
 
     assert.rejects(
@@ -71,8 +71,8 @@ module('[@glimmer/core] non-interactive - helper', () => {
     }
 
     setComponentTemplate(
-      MyComponent,
-      createTemplate({ myHelper }, '<h1>{{myHelper this.name greeting="Hello"}}</h1>')
+      createTemplate({ myHelper }, '<h1>{{myHelper this.name greeting="Hello"}}</h1>'),
+      MyComponent
     );
 
     const html = await render(MyComponent);
@@ -101,9 +101,10 @@ module('[@glimmer/core] non-interactive - helper', () => {
       }
     );
 
-    const MyComponent = templateOnlyComponent();
-
-    setComponentTemplate(MyComponent, createTemplate({ myHelper }, '<h1>{{myHelper}}</h1>'));
+    const MyComponent = setComponentTemplate(
+      createTemplate({ myHelper }, '<h1>{{myHelper}}</h1>'),
+      templateOnlyComponent()
+    );
 
     const html = await render(MyComponent, {
       owner: new Owner(),

--- a/packages/@glimmer/core/test/non-interactive/render-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/render-test.ts
@@ -6,8 +6,8 @@ import { on, action } from '@glimmer/modifier';
 import {
   setComponentTemplate,
   createTemplate,
-  templateOnlyComponent,
   getOwner,
+  templateOnlyComponent,
 } from '@glimmer/core';
 
 import { module, test, render } from '../utils';
@@ -17,7 +17,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
   test('it renders a component', async (assert) => {
     class MyComponent extends Component {}
 
-    setComponentTemplate(MyComponent, createTemplate(`<h1>Hello world</h1>`));
+    setComponentTemplate(createTemplate(`<h1>Hello world</h1>`), MyComponent);
 
     const html = await render(MyComponent);
     assert.strictEqual(html, '<h1>Hello world</h1>', 'the template was rendered');
@@ -27,12 +27,12 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
   test('a component can render a nested component', async (assert) => {
     class OtherComponent extends Component {}
 
-    setComponentTemplate(OtherComponent, createTemplate(`Hello world`));
+    setComponentTemplate(createTemplate(`Hello world`), OtherComponent);
 
     class MyComponent extends Component {}
     setComponentTemplate(
-      MyComponent,
-      createTemplate({ OtherComponent }, `<h1><OtherComponent /></h1>`)
+      createTemplate({ OtherComponent }, `<h1><OtherComponent /></h1>`),
+      MyComponent
     );
 
     const html = await render(MyComponent);
@@ -42,21 +42,21 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
 
   test('a component can render multiple nested components', async (assert) => {
     class Foo extends Component {}
-    setComponentTemplate(Foo, createTemplate(`Foo`));
+    setComponentTemplate(createTemplate(`Foo`), Foo);
 
     class Bar extends Component {}
-    setComponentTemplate(Bar, createTemplate(`Bar`));
+    setComponentTemplate(createTemplate(`Bar`), Bar);
 
     class OtherComponent extends Component {}
     setComponentTemplate(
-      OtherComponent,
-      createTemplate({ Foo, Bar }, `Hello world <Foo /><Bar />`)
+      createTemplate({ Foo, Bar }, `Hello world <Foo /><Bar />`),
+      OtherComponent
     );
 
     class MyComponent extends Component {}
     setComponentTemplate(
-      MyComponent,
-      createTemplate({ OtherComponent }, `<h1><OtherComponent /></h1>`)
+      createTemplate({ OtherComponent }, `<h1><OtherComponent /></h1>`),
+      MyComponent
     );
 
     const html = await render(MyComponent);
@@ -65,9 +65,10 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
   });
 
   test('custom elements are rendered', async function (assert) {
-    const component = templateOnlyComponent();
-
-    setComponentTemplate(component, createTemplate('<hello-world>foo</hello-world>'));
+    const component = setComponentTemplate(
+      createTemplate('<hello-world>foo</hello-world>'),
+      templateOnlyComponent()
+    );
 
     assert.equal(await render(component), '<hello-world>foo</hello-world>');
   });
@@ -75,7 +76,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
   test('a component can render with args', async (assert) => {
     class MyComponent extends Component {}
 
-    setComponentTemplate(MyComponent, createTemplate('<h1>{{@say}}</h1>'));
+    setComponentTemplate(createTemplate('<h1>{{@say}}</h1>'), MyComponent);
 
     const renderOptions = {
       args: {
@@ -96,16 +97,17 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
       salutation = 'Glimmer';
     }
 
-    const HelloWorld = templateOnlyComponent();
-
-    setComponentTemplate(HelloWorld, createTemplate('{{yield @name}}!'));
+    const HelloWorld = setComponentTemplate(
+      createTemplate('{{yield @name}}!'),
+      templateOnlyComponent()
+    );
 
     setComponentTemplate(
-      MainComponent,
       createTemplate(
         { HelloWorld },
         '<HelloWorld @name={{this.salutation}} as |name|>{{name}}</HelloWorld>'
-      )
+      ),
+      MainComponent
     );
 
     assert.equal(await render(MainComponent), 'Glimmer!');
@@ -131,8 +133,8 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
       }
 
       setComponentTemplate(
-        Main,
-        createTemplate('Hello {{if this.pred this.salutation this.alternative}}!')
+        createTemplate('Hello {{if this.pred this.salutation this.alternative}}!'),
+        Main
       );
 
       assert.equal(
@@ -158,11 +160,11 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     }
 
     setComponentTemplate(
-      Main,
       createTemplate(
         { if: () => assert.ok(false, 'custom if was called') },
         'Hello {{if this.pred this.salutation this.alternative}}!'
-      )
+      ),
+      Main
     );
 
     assert.equal(await render(Main), 'Hello Glimmer!', 'output is correct');
@@ -202,7 +204,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
       }
     }
 
-    setComponentTemplate(MyComponent, createTemplate('<h1>{{this.myLocale}}</h1>'));
+    setComponentTemplate(createTemplate('<h1>{{this.myLocale}}</h1>'), MyComponent);
 
     const html = await render(MyComponent, {
       owner: new Owner(),
@@ -214,7 +216,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
   test('a component can be rendered more than once', async (assert) => {
     class MyComponent extends Component {}
 
-    setComponentTemplate(MyComponent, createTemplate(`<h1>Bump</h1>`));
+    setComponentTemplate(createTemplate(`<h1>Bump</h1>`), MyComponent);
 
     let html = await render(MyComponent);
     assert.strictEqual(html, '<h1>Bump</h1>', 'the component rendered');
@@ -236,11 +238,11 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     }
 
     setComponentTemplate(
-      MyComponent,
       createTemplate(
         { on },
         `<button {{on "click" this.incrementCounter}}>Count: {{this.count}}</button>`
-      )
+      ),
+      MyComponent
     );
 
     const html = await render(MyComponent);
@@ -250,7 +252,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
   test('it can set a dynamic href on an anchor', async (assert) => {
     class MyComponent extends Component {}
 
-    setComponentTemplate(MyComponent, createTemplate(`<a href={{@href}}>Link</a>`));
+    setComponentTemplate(createTemplate(`<a href={{@href}}>Link</a>`), MyComponent);
 
     const html = await render(MyComponent, { args: { href: 'www.example.com' } });
     assert.strictEqual(html, '<a href="www.example.com">Link</a>', 'the template was rendered');
@@ -259,7 +261,7 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
   test('it can set a dynamic src on an img', async (assert) => {
     class MyComponent extends Component {}
 
-    setComponentTemplate(MyComponent, createTemplate(`<img src={{@src}}/>`));
+    setComponentTemplate(createTemplate(`<img src={{@src}}/>`), MyComponent);
 
     const html = await render(MyComponent, { args: { src: './logo.svg' } });
     assert.strictEqual(html, '<img src="./logo.svg">', 'the template was rendered');
@@ -269,8 +271,10 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     test('accessing properties in template-only components produces a helpful error in development mode', async function (assert) {
       assert.expect(1);
 
-      const component = templateOnlyComponent();
-      setComponentTemplate(component, createTemplate('<h1>Hello, {{this.name}}!</h1>'));
+      const component = setComponentTemplate(
+        createTemplate('<h1>Hello, {{this.name}}!</h1>'),
+        templateOnlyComponent()
+      );
 
       try {
         await render(component);
@@ -286,8 +290,10 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     test('accessing properties in template-only components produces an exception in production mode', async function (assert) {
       assert.expect(1);
 
-      const component = templateOnlyComponent();
-      setComponentTemplate(component, createTemplate('<h1>Hello, {{this.name}}!</h1>'));
+      const component = setComponentTemplate(
+        createTemplate('<h1>Hello, {{this.name}}!</h1>'),
+        templateOnlyComponent()
+      );
 
       try {
         await render(component);

--- a/packages/@glimmer/core/test/non-interactive/strict-mode-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/strict-mode-test.ts
@@ -13,7 +13,7 @@ if (DEBUG) {
           say = 'Hello Dolly!';
         }
 
-        setComponentTemplate(MyComponent, createTemplate('<h1>{{say}}</h1>'));
+        setComponentTemplate(createTemplate('<h1>{{say}}</h1>'), MyComponent);
       }, /Error: Cannot find identifier `say` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `{{this.say}}`/);
     });
 
@@ -28,8 +28,8 @@ if (DEBUG) {
         }
 
         setComponentTemplate(
-          MyComponent,
-          createTemplate({ myHelper }, '<h1>{{myHelper say}}</h1>')
+          createTemplate({ myHelper }, '<h1>{{myHelper say}}</h1>'),
+          MyComponent
         );
       }, /Error: Cannot find identifier `say` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `{{this.say}}`/);
     });
@@ -40,7 +40,7 @@ if (DEBUG) {
           say = 'Hello Dolly!';
         }
 
-        setComponentTemplate(MyComponent, createTemplate('<h1>{{say this.bar}}</h1>'));
+        setComponentTemplate(createTemplate('<h1>{{say this.bar}}</h1>'), MyComponent);
       }, /Error: Cannot find identifier `say` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `{{this.say}}`/);
     });
 
@@ -50,7 +50,7 @@ if (DEBUG) {
           say = 'Hello Dolly!';
         }
 
-        setComponentTemplate(MyComponent, createTemplate('<h1 {{say}}>Hello Dolly!</h1>'));
+        setComponentTemplate(createTemplate('<h1 {{say}}>Hello Dolly!</h1>'), MyComponent);
       }, /Error: Cannot find identifier `say` in scope. It was used in a template, but not imported into the template scope or defined as a local variable. If you meant to access a property, you must add `this` to it: `{{this.say}}`/);
     });
 

--- a/packages/@glimmer/core/test/non-interactive/to-bool-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/to-bool-test.ts
@@ -13,8 +13,8 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     }
 
     setComponentTemplate(
-      Main,
-      createTemplate('Hello {{if this.pred this.salutation this.alternative}}!')
+      createTemplate('Hello {{if this.pred this.salutation this.alternative}}!'),
+      Main
     );
 
     assert.equal(await render(Main), `Hello Glimmer.js!`, 'output is correct');
@@ -26,8 +26,8 @@ module(`[@glimmer/core] non-interactive rendering tests`, () => {
     }
 
     setComponentTemplate(
-      Main,
-      createTemplate('Hello {{#if this.pred}}Glimmer{{else}}Glimmer.js{{/if}}!')
+      createTemplate('Hello {{#if this.pred}}Glimmer{{else}}Glimmer.js{{/if}}!'),
+      Main
     );
 
     assert.equal(await render(Main), `Hello Glimmer.js!`, 'output is correct');

--- a/packages/@glimmer/core/test/utils.ts
+++ b/packages/@glimmer/core/test/utils.ts
@@ -3,8 +3,8 @@ import {
   ComponentDefinition,
   RenderComponentOptions,
   didRender,
-  templateOnlyComponent,
   setComponentTemplate,
+  templateOnlyComponent,
 } from '..';
 import { renderToString } from '@glimmer/ssr';
 import { SerializedTemplateWithLazyBlock } from '@glimmer/interfaces';
@@ -25,9 +25,7 @@ export async function render(
   if ('id' in component && 'block' in component && 'meta' in component) {
     const template = component;
 
-    component = templateOnlyComponent();
-
-    setComponentTemplate(component, template);
+    component = setComponentTemplate(template, templateOnlyComponent());
   }
 
   if (IS_INTERACTIVE) {

--- a/packages/@glimmer/ssr/test/modifiers-test.ts
+++ b/packages/@glimmer/ssr/test/modifiers-test.ts
@@ -45,8 +45,8 @@ QUnit.module('@glimmer/ssr modifiers', () => {
 
     const Component = templateOnlyComponent();
     setComponentTemplate(
-      Component,
-      createTemplate({ modifier: Modifier }, '<h1 {{modifier}}>hello world</h1>')
+      createTemplate({ modifier: Modifier }, '<h1 {{modifier}}>hello world</h1>'),
+      Component
     );
 
     const output = await renderToString(Component);

--- a/packages/@glimmer/ssr/test/render-options-tests.ts
+++ b/packages/@glimmer/ssr/test/render-options-tests.ts
@@ -17,7 +17,7 @@ QUnit.module('@glimmer/ssr rendering', () => {
 
     const options: RenderOptions = { serializer: new CustomHTMLSerializer(voidMap) };
 
-    setComponentTemplate(MyComponent, createTemplate(`<h1>Hello World</h1>`));
+    setComponentTemplate(createTemplate(`<h1>Hello World</h1>`), MyComponent);
 
     const output = await renderToString(MyComponent, options);
 

--- a/packages/example-apps/basic/src/MyComponent.ts
+++ b/packages/example-apps/basic/src/MyComponent.ts
@@ -1,11 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import {
-  createTemplate,
-  setComponentTemplate,
-  templateOnlyComponent,
-  getOwner,
-} from '@glimmer/core';
+import { createTemplate, setComponentTemplate, getOwner } from '@glimmer/core';
 import { helper } from './utils/helper-with-services';
 import OtherComponent from './OtherComponent';
 import { on, action } from '@glimmer/modifier';
@@ -26,10 +21,7 @@ const isCJK = helper(function (_args, _hash, services) {
   return true;
 });
 
-const TemplateOnlyComponent = templateOnlyComponent();
-
-setComponentTemplate(
-  TemplateOnlyComponent,
+const TemplateOnlyComponent = setComponentTemplate(
   createTemplate(`<h1>I am rendered by a template only component: {{@name}}</h1>`)
 );
 
@@ -48,7 +40,6 @@ class MyComponent extends Component {
 }
 
 setComponentTemplate(
-  MyComponent,
   createTemplate(
     { OtherComponent, TemplateOnlyComponent, myHelper, isCJK, on },
     `
@@ -65,7 +56,8 @@ setComponentTemplate(
       <button {{on "click" this.increment}}>Increment</button>
       <TemplateOnlyComponent @name="For Glimmer"/>
     `
-  )
+  ),
+  MyComponent
 );
 
 export default MyComponent;

--- a/packages/example-apps/basic/src/OtherComponent.ts
+++ b/packages/example-apps/basic/src/OtherComponent.ts
@@ -3,4 +3,4 @@ import { createTemplate, setComponentTemplate } from '@glimmer/core';
 
 export default class OtherComponent extends Component {}
 
-setComponentTemplate(OtherComponent, createTemplate(`<b>Counter Val: {{@count}}</b>`));
+setComponentTemplate(createTemplate(`<b>Counter Val: {{@count}}</b>`), OtherComponent);


### PR DESCRIPTION
The current implementation has the component class and template parameters backwards. This PR updates the implementation here to match Ember's.