### PR TITLE
[CHORE] Update to glimmer-vm version 0.51.0

### DIFF
--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@glimmer/env": "^0.1.7",
-    "@glimmer/util": "^0.50.0",
+    "@glimmer/util": "^0.51.0",
     "@glimmer/core": "2.0.0-beta.6",
     "broccoli-file-creator": "^2.1.1",
     "broccoli-merge-trees": "^3.0.2",
@@ -43,11 +43,11 @@
   "devDependencies": {
     "@ember/optional-features": "^0.6.1",
     "@glimmer/application-test-helpers": "^1.0.0",
-    "@glimmer/compiler": "^0.50.0",
-    "@glimmer/interfaces": "^0.50.0",
+    "@glimmer/compiler": "^0.51.0",
+    "@glimmer/interfaces": "^0.51.0",
     "@glimmer/resolver": "^0.3.0",
     "@glimmer/tracking": "2.0.0-beta.6",
-    "@glimmer/wire-format": "^0.50.0",
+    "@glimmer/wire-format": "^0.51.0",
     "@types/ember": "~3.0.29",
     "@types/ember-qunit": "~3.4.3",
     "@types/ember-test-helpers": "~1.0.6",

--- a/packages/@glimmer/core/package.json
+++ b/packages/@glimmer/core/package.json
@@ -13,15 +13,15 @@
   },
   "dependencies": {
     "@glimmer/env": "^0.1.7",
-    "@glimmer/interfaces": "^0.50.0",
-    "@glimmer/opcode-compiler": "^0.50.0",
-    "@glimmer/runtime": "^0.50.0",
-    "@glimmer/validator": "^0.50.0",
+    "@glimmer/interfaces": "^0.51.0",
+    "@glimmer/opcode-compiler": "^0.51.0",
+    "@glimmer/runtime": "^0.51.0",
+    "@glimmer/validator": "^0.51.0",
     "@simple-dom/interface": "^1.4.0"
   },
   "devDependencies": {
-    "@glimmer/bundle-compiler": "^0.50.0",
-    "@glimmer/compiler": "^0.50.0",
+    "@glimmer/bundle-compiler": "^0.51.0",
+    "@glimmer/compiler": "^0.51.0",
     "@glimmer/component": "2.0.0-beta.6",
     "@glimmer/tracking": "2.0.0-beta.6"
   },

--- a/packages/@glimmer/helper/package.json
+++ b/packages/@glimmer/helper/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "@glimmer/component": "2.0.0-beta.6",
     "@glimmer/core": "2.0.0-beta.6",
-    "@glimmer/interfaces": "^0.50.0",
-    "@glimmer/reference": "^0.50.0"
+    "@glimmer/interfaces": "^0.51.0",
+    "@glimmer/reference": "^0.51.0"
   },
   "volta": {
     "node": "12.16.1",

--- a/packages/@glimmer/modifier/package.json
+++ b/packages/@glimmer/modifier/package.json
@@ -12,7 +12,7 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/interfaces": "^0.50.0",
+    "@glimmer/interfaces": "^0.51.0",
     "@simple-dom/interface": "^1.4.0"
   },
   "volta": {

--- a/packages/@glimmer/ssr/package.json
+++ b/packages/@glimmer/ssr/package.json
@@ -11,10 +11,10 @@
   "module": "dist/modules/index.js",
   "dependencies": {
     "@glimmer/core": "2.0.0-beta.6",
-    "@glimmer/node": "^0.50.0",
-    "@glimmer/reference": "^0.50.0",
-    "@glimmer/runtime": "^0.50.0",
-    "@glimmer/util": "^0.50.0",
+    "@glimmer/node": "^0.51.0",
+    "@glimmer/reference": "^0.51.0",
+    "@glimmer/runtime": "^0.51.0",
+    "@glimmer/util": "^0.51.0",
     "@simple-dom/document": "^1.4.0",
     "@simple-dom/serializer": "^1.4.0",
     "@simple-dom/void-map": "^1.4.0"

--- a/packages/@glimmer/tracking/package.json
+++ b/packages/@glimmer/tracking/package.json
@@ -15,14 +15,14 @@
   "module": "dist/modules/index.js",
   "dependencies": {
     "@glimmer/env": "^0.1.7",
-    "@glimmer/validator": "^0.50.0"
+    "@glimmer/validator": "^0.51.0"
   },
   "devDependencies": {
     "@glimmer/application-test-helpers": "^1.0.0",
-    "@glimmer/compiler": "^0.50.0",
-    "@glimmer/interfaces": "^0.50.0",
+    "@glimmer/compiler": "^0.51.0",
+    "@glimmer/interfaces": "^0.51.0",
     "@glimmer/resolver": "^0.3.0",
-    "@glimmer/wire-format": "^0.50.0"
+    "@glimmer/wire-format": "^0.51.0"
   },
   "volta": {
     "node": "12.16.1",

--- a/packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/package.json
+++ b/packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-module-imports": "^7.0.0",
     "@babel/parser": "^7.9.4",
     "@babel/types": "^7.9.0",
-    "@glimmer/compiler": "0.50.0"
+    "@glimmer/compiler": "0.51.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,28 +972,28 @@
     "@glimmer/util" "^0.44.0"
     "@glimmer/wire-format" "^0.44.0"
 
-"@glimmer/bundle-compiler@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/bundle-compiler/-/bundle-compiler-0.50.0.tgz#48ebed8bc14e8cb43ddac87d6c40a712d04ea446"
-  integrity sha512-d7RPgaeMxjWUCKeIRoSGUUuUNV560hRf1iRs/HKc3fj3/Op3uxg2YbhUMTROQM37XYj8/PucZpxhVA725v7ynQ==
+"@glimmer/bundle-compiler@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/bundle-compiler/-/bundle-compiler-0.51.0.tgz#d4051a8d0323bdad5b0694a86545ae6e25da4214"
+  integrity sha512-Xm+Ozlw5UGI/Nq3lkH6sYG7ElMd8BGUOPmmuAJp9LeB9hC5MbQ3lPcc4axuLYAw/x6oJN+a0dmcRyRpd9aQ1/g==
   dependencies:
-    "@glimmer/compiler" "^0.50.0"
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/opcode-compiler" "^0.50.0"
-    "@glimmer/program" "^0.50.0"
-    "@glimmer/syntax" "^0.50.0"
-    "@glimmer/util" "^0.50.0"
-    "@glimmer/wire-format" "^0.50.0"
+    "@glimmer/compiler" "^0.51.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/opcode-compiler" "^0.51.0"
+    "@glimmer/program" "^0.51.0"
+    "@glimmer/syntax" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
+    "@glimmer/wire-format" "^0.51.0"
 
-"@glimmer/compiler@0.50.0", "@glimmer/compiler@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.50.0.tgz#ace8e05fa1b768b73571ad945dbbfab4178793de"
-  integrity sha512-jhruI6Y2hmchiPE0olCRhTY5HMZVe1Mm3V2tZh8Vatq1s74/uvUu8XaaK87Ij3eBNFVTAa7KhrTtkuEA85J5nw==
+"@glimmer/compiler@0.51.0", "@glimmer/compiler@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.51.0.tgz#35b287db3da96b8de9ab1efafa49ab041c68398e"
+  integrity sha512-TXQw4AyNJOpHcOlO5h1U3Yf5X9aAfeiC5VJavsNXsNtzx22/RfSalsMXPjc6R4IzLP9ihjlMEK/uG8MncsOUyg==
   dependencies:
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/syntax" "^0.50.0"
-    "@glimmer/util" "^0.50.0"
-    "@glimmer/wire-format" "^0.50.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/syntax" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
+    "@glimmer/wire-format" "^0.51.0"
     "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/compiler@^0.44.0":
@@ -1024,13 +1024,13 @@
     "@glimmer/interfaces" "^0.44.0"
     "@glimmer/vm" "^0.44.0"
 
-"@glimmer/encoder@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.50.0.tgz#96c1b52928f8b97aadb52c66158a3577ed883e45"
-  integrity sha512-rcoh/zlbsRDhHjWb1gWNIpjfrV44gI9Na0ktCscPhifZGnyNbkRtFB1ybRZRywStshmTcFHytC3l4StM60XQtg==
+"@glimmer/encoder@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.51.0.tgz#a8c7dfd760964ecd53d7def550a66e3e9564ba62"
+  integrity sha512-EakrjpISwKf7NQlbo+beq8mxt3njcLt1ciqs51NL8pMDachaCtY57wTUSVXN9URb230dyGxU0VbWMKBeqvjTOA==
   dependencies:
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/vm" "^0.50.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/vm" "^0.51.0"
 
 "@glimmer/env@0.1.7", "@glimmer/env@^0.1.7":
   version "0.1.7"
@@ -1042,10 +1042,10 @@
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.44.0.tgz#0896204815f05fd8907b5703cbaee9d1b9edf5d3"
   integrity sha512-O1VBrB1uhWh/XpBRaMbT5zncZiJJNTAqe0rnhRr4JicrlmNoIC4/5ADRgDORj5oBxuENjuZ+6UTul3WCOHETiw==
 
-"@glimmer/interfaces@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.50.0.tgz#ad556592ecccd44afb5bbd08906734d63a178d02"
-  integrity sha512-z62FdxACLmIiAaM9sx34kTVGnip4OaKcUHbrtRhKR54o3XdR/wyJ4iibIRqGR8xLPz2XbOoyarDQ1QmYJBU8Mg==
+"@glimmer/interfaces@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.51.0.tgz#a25ee61a302bcb8ee45b4b9f7e825a8af5874b49"
+  integrity sha512-QouZvCRnIpeRFAgEsk5T7FXVQ7xzUNRMDPfEfNXoTPlEYkbC2J9BngaTo0U2Un6OGHt/du8DqEw7gXurBe9SNQ==
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
@@ -1054,34 +1054,34 @@
   resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.44.0.tgz#c164efc7e946d7cbbe54c258e64b9148e971c871"
   integrity sha512-qOayju1J3vpQUT21QxafbP/7EIxY0ve5B9Biyk3i9MCb1BRnTL2OPoNK7Ia5uuA8qbwIk/PuNqx+uHYoOipXMw==
 
-"@glimmer/low-level@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.50.0.tgz#e013e0cd3c6a223499f59699e7d809136379bb41"
-  integrity sha512-PwCeYk61UUl6ZfGBg7X4qXc3NqezTHbytsZbdsnZCMQvsnzeuQMUUQKof4a0bY5tVlA7LdpgAnt6lajw2Hj6aw==
+"@glimmer/low-level@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.51.0.tgz#04c3caf774a9ef458dbd9b07f4955b09873ea27a"
+  integrity sha512-pZit5wGMn8M8Tl/aoeRgNR5v16vr0Q+dsx+2/itA0I+1LubBSqDfZUa3ye2Ut1nwjKY8qzwH7T6gr/ef9taeeQ==
 
-"@glimmer/node@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.50.0.tgz#e9eccf3f79066f0f19b1aa8ac6711f1ed44dc2f9"
-  integrity sha512-HaVxd971efNEDa5FTG1HNdEjVBMdJ8WgOQB4x3CSZXBNuBRSAfD7pbPn71AlCFSHaZNdnfhSI82yt7qOrl858Q==
+"@glimmer/node@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.51.0.tgz#d945c270f2a78ce7767e5e011dbffd8092a6a79c"
+  integrity sha512-G9x7qtpRFPyju17fPMTrP3KRqeKJmlW81seXQM34enKMoB6q84jjLcT3VzpdH7rmqJkfUM7zCqRFTjzP8TixEw==
   dependencies:
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/runtime" "^0.50.0"
-    "@glimmer/util" "^0.50.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/runtime" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
     "@simple-dom/document" "^1.4.0"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/opcode-compiler@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.50.0.tgz#a9af840b957721e14792596d9605a1df536823ad"
-  integrity sha512-26qfK5kMzVkRaaQdlEgR41YburJz5DTWsVI7g2pyqMm2GKPMMGhs17URqkDAhZqL4KNr7H1NCJQgtl394/oJxg==
+"@glimmer/opcode-compiler@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.51.0.tgz#30d537648262c95e06f26a46df82209d3958fcc7"
+  integrity sha512-hE2bGKkmga5AfkeAV806UppL/w2/wylDTMfBOu71/ZORYvDdFDCGvzL+bE8yy44e+LteIJhOPvRD7+YvNkRstQ==
   dependencies:
-    "@glimmer/encoder" "^0.50.0"
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/program" "^0.50.0"
-    "@glimmer/reference" "^0.50.0"
-    "@glimmer/util" "^0.50.0"
-    "@glimmer/vm" "^0.50.0"
-    "@glimmer/wire-format" "^0.50.0"
+    "@glimmer/encoder" "^0.51.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/program" "^0.51.0"
+    "@glimmer/reference" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
+    "@glimmer/vm" "^0.51.0"
+    "@glimmer/wire-format" "^0.51.0"
 
 "@glimmer/program@^0.44.0":
   version "0.44.0"
@@ -1092,14 +1092,14 @@
     "@glimmer/interfaces" "^0.44.0"
     "@glimmer/util" "^0.44.0"
 
-"@glimmer/program@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.50.0.tgz#751ffbf3af988ea51f0f38088f26de2eef072a14"
-  integrity sha512-XH6MjptzCwBwTjfNRaWmJhTNfDBYzc+11mLsIZQFbtrJaaPKRBXFcc6w/FwUihppt4wPwwF/vsvC/8t4yz5VRA==
+"@glimmer/program@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.51.0.tgz#02af329dec6241d806ee1962f7aa8d17b6a114c0"
+  integrity sha512-KBZmVSb8wacoB3PwF72xsJV+F+tdXBklS6qqF0GMdJEWJhp53z2jTElSDnODNY2Rf+lnq9u3GrrfZMQmGjkgbw==
   dependencies:
-    "@glimmer/encoder" "^0.50.0"
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/util" "^0.50.0"
+    "@glimmer/encoder" "^0.51.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
 
 "@glimmer/reference@^0.44.0":
   version "0.44.0"
@@ -1109,15 +1109,15 @@
     "@glimmer/util" "^0.44.0"
     "@glimmer/validator" "^0.44.0"
 
-"@glimmer/reference@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.50.0.tgz#700aa689d488865c4431811ed8d04bc445c70a75"
-  integrity sha512-h4ckpgY+LIagoQYAXPuF0HhFR6Sb1F23zJALqSq9VwuqIVzbGf7i29JnCsS1XeXKj/sFkvitzpaFjbJQnbQtRg==
+"@glimmer/reference@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.51.0.tgz#1d25e088dc91af7884bc4a881202b3ee0cabb094"
+  integrity sha512-tnWa93CRj1O61IoCKgdJh910rgPy1UmV1zAykcSVd26YKS6oqnh6lLMww+apToCJB3llLbp71qzjZVR35eb7Mg==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/util" "^0.50.0"
-    "@glimmer/validator" "^0.50.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
+    "@glimmer/validator" "^0.51.0"
 
 "@glimmer/resolver@^0.3.0":
   version "0.3.1"
@@ -1147,20 +1147,20 @@
     "@glimmer/vm" "^0.44.0"
     "@glimmer/wire-format" "^0.44.0"
 
-"@glimmer/runtime@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.50.0.tgz#a42cea89092eee4d01db73aefbfbcf9ec269b299"
-  integrity sha512-gx6tR4129k/6i6lZuohV7hXMXNnwYARnkBLYyoMgfJQK+xRZu8OyfNkj7LeD1pcP1ZkTXbaGx58BNjvFyaj2kg==
+"@glimmer/runtime@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.51.0.tgz#fbde6e563e5532f050ebee6ed2b1f21506c66f80"
+  integrity sha512-RwpaI6K8FGMA39Hw1dzjuXbOuoCsYavW1tZChEO23wZuO2QawggpGXDV9R5czqDYr0k6a2mKs8nZNgTIsf61Yg==
   dependencies:
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/low-level" "^0.50.0"
-    "@glimmer/program" "^0.50.0"
-    "@glimmer/reference" "^0.50.0"
-    "@glimmer/util" "^0.50.0"
-    "@glimmer/validator" "^0.50.0"
-    "@glimmer/vm" "^0.50.0"
-    "@glimmer/wire-format" "^0.50.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/low-level" "^0.51.0"
+    "@glimmer/program" "^0.51.0"
+    "@glimmer/reference" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
+    "@glimmer/validator" "^0.51.0"
+    "@glimmer/vm" "^0.51.0"
+    "@glimmer/wire-format" "^0.51.0"
     "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/syntax@^0.44.0":
@@ -1173,14 +1173,14 @@
     handlebars "^4.5.1"
     simple-html-tokenizer "^0.5.8"
 
-"@glimmer/syntax@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.50.0.tgz#a56eac20972e3fc60f55b39112d1e113b55f0652"
-  integrity sha512-T04MubWW8fkc54Dg9py6Y/PaWI+o0CDK+LVj0z9oIiTO+ehEmntUpIcuuVDpAB+/5GCqEOZhuxq/agnm5m6EIw==
+"@glimmer/syntax@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.51.0.tgz#f9d258e9a763e91b751a7dbdb51c0a338da54ba8"
+  integrity sha512-gRmlZBrlAwPj53ZO69SbPi8JXQBrGqheB1OvWtJilTmUKz5nPVt8J5E8ttvS7yotRWrht/jO7qOr3s4GlWp5pA==
   dependencies:
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/util" "^0.50.0"
-    handlebars "^4.5.1"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
+    handlebars "^4.7.4"
     simple-html-tokenizer "^0.5.9"
 
 "@glimmer/util@^0.44.0":
@@ -1188,13 +1188,13 @@
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.44.0.tgz#45df98d73812440206ae7bda87cfe04aaae21ed9"
   integrity sha512-duAsm30uVK9jSysElCbLyU6QQYO2X9iLDLBIBUcCqck9qN1o3tK2qWiHbGK5d6g8E2AJ4H88UrfElkyaJlGrwg==
 
-"@glimmer/util@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.50.0.tgz#cdb930f822a59083a52cbac6aa0dd7b514428448"
-  integrity sha512-mzSyXtd/cMOgISODsWbaUrx97gbo8sNqQ7+l+7hZrlWjltoaSjsV7rGn+Oc8V7Du76XBS8Ctu/EqfcOeJS8YBA==
+"@glimmer/util@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.51.0.tgz#cb664724608a88bb6c249e34284e54c8ac428831"
+  integrity sha512-FnD+GTD2QsG9YShTBY4GSTd8lAtheXTjJxuZW0OF4Mzeb77kW49lrM0vFh/6OciOqfwQf4rp+7EU0KDFqpGFtg==
   dependencies:
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "^0.50.0"
+    "@glimmer/interfaces" "^0.51.0"
     "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/validator@^0.44.0":
@@ -1202,10 +1202,10 @@
   resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
   integrity sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==
 
-"@glimmer/validator@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.50.0.tgz#3c099785c778f2feb827773569cbe809e0898acd"
-  integrity sha512-BkKtbWOMT4kw7q8GNfGRY6+sxxF+NNva6L149apf1BUKVRC94rnTFamLyvetsoqzZhR9HWleg0S8Cyrs+7wruQ==
+"@glimmer/validator@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.51.0.tgz#3c4074bf7fb774e373caf17d8187afaf367d17e9"
+  integrity sha512-bH7o0FBaYWx7gcKC/5oEL3asQYYDx31N5WNFl9qZ3PjlyPYq73qqwvEbAYbwcByI55a176fnh+mQoUZsDkYGeA==
   dependencies:
     "@glimmer/env" "^0.1.7"
 
@@ -1217,13 +1217,13 @@
     "@glimmer/interfaces" "^0.44.0"
     "@glimmer/util" "^0.44.0"
 
-"@glimmer/vm@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.50.0.tgz#2867b08aabc9f839847eefacc5d0aa075fe490ed"
-  integrity sha512-LJXunrLa9rxECItuAuXeFuN795CvHQcpPB/rncDiiguv5m/sLG617Dz0VQ+TRuj1HNdPoSyiKY2/lBL+5uAPig==
+"@glimmer/vm@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.51.0.tgz#0e6086ee7801730da1a9c4fb3542a8c94795898f"
+  integrity sha512-s7hbl359mmjVBt9lFAaCHvwnFvJ6T7z+0eh6kjhWmHDCJ7cSzMIcjA/B3psMwzojrEj+xFUHPWZJ2px+8NuQXA==
   dependencies:
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/util" "^0.50.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
 
 "@glimmer/wire-format@^0.44.0":
   version "0.44.0"
@@ -1233,13 +1233,13 @@
     "@glimmer/interfaces" "^0.44.0"
     "@glimmer/util" "^0.44.0"
 
-"@glimmer/wire-format@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.50.0.tgz#ee39d34abca91903c58d161b5b710e01696fea9f"
-  integrity sha512-omvQ2/I0SkAbl584RdmZMLZLeTZz5Pd0m/Ce9x2JQLpG2gR62UIJo+IfL0RgtTMeNYYnEhddYBM/bNRFZ1fcUw==
+"@glimmer/wire-format@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.51.0.tgz#34264470fce4e109120e2304a45f0eac2c8b4c2e"
+  integrity sha512-OrxNVw41ZKsw32cafR+mlVg8e552sx4NT4Ctg/0aqBv0jfON14eqjM+z3JznHnUbz8HdsrVvH9IdVu2rIP8IVA==
   dependencies:
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/util" "^0.50.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
 
 "@iarna/toml@2.2.3":
   version "2.2.3"
@@ -7051,6 +7051,18 @@ handlebars@^4.0.4, handlebars@^4.5.1:
     neo-async "^2.6.0"
     optimist "^0.6.1"
     source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+handlebars@^4.7.4:
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
+  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
 
@@ -12902,6 +12914,11 @@ word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
Use latest glimmer-vm which swaps the main entry point for node to es2017.