### PR TITLE
Add Ember 3.8, 3.12, 3.16, and 3.20 to @glimmer/component CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,7 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.12
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.16
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.20

--- a/packages/@glimmer/component/config/ember-try.js
+++ b/packages/@glimmer/component/config/ember-try.js
@@ -20,6 +20,38 @@ module.exports = function() {
           },
         },
         {
+          name: 'ember-lts-3.8',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.8.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.12',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.12.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.16',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.16.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.20',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.20.0',
+            },
+          },
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {


### PR DESCRIPTION
Note: this targets the v1.x branch (I'll have another PR targeting master)