### PR TITLE
Check for `meta.destroy` to avoid deprecation in ember 3.20 series

### DIFF
--- a/packages/@glimmer/component/addon/-private/ember-component-manager.ts
+++ b/packages/@glimmer/component/addon/-private/ember-component-manager.ts
@@ -47,7 +47,7 @@ class EmberGlimmerComponentManager extends BaseComponentManager<GlimmerComponent
 
     const meta = Ember.meta(component);
 
-    meta.setSourceDestroying();
+    meta.destroy ? meta.destroy() : meta.setSourceDestroying();
     setDestroying(component);
 
     schedule('actions', component, component.willDestroy);


### PR DESCRIPTION
Relates to this issue https://github.com/emberjs/ember.js/issues/19042