### PR TITLE
Leverage built-in destroyables on Ember 3.20+ to avoid deprecations

### DIFF
--- a/packages/@glimmer/component/addon/-private/component.ts
+++ b/packages/@glimmer/component/addon/-private/component.ts
@@ -1,15 +1,6 @@
 import { DEBUG } from '@glimmer/env';
 import { setOwner } from './owner';
-
-const DESTROYING = new WeakMap<BaseComponent<unknown>, boolean>();
-const DESTROYED = new WeakMap<BaseComponent<unknown>, boolean>();
-
-export function setDestroying(component: BaseComponent<unknown>) {
-  DESTROYING.set(component, true);
-}
-export function setDestroyed(component: BaseComponent<unknown>) {
-  DESTROYED.set(component, true);
-}
+import { isDestroying, isDestroyed } from './destroyables';
 
 export let ARGS_SET: WeakMap<any, boolean>;
 
@@ -160,9 +151,6 @@ export default class BaseComponent<T = object> {
 
     this.args = args;
     setOwner(this, owner as any);
-
-    DESTROYING.set(this, false);
-    DESTROYED.set(this, false);
   }
 
   /**
@@ -192,11 +180,11 @@ export default class BaseComponent<T = object> {
   args: Readonly<T>;
 
   get isDestroying() {
-    return DESTROYING.get(this);
+    return isDestroying(this);
   }
 
   get isDestroyed() {
-    return DESTROYED.get(this);
+    return isDestroyed(this);
   }
 
   /**

--- a/packages/@glimmer/component/addon/-private/destroyables.ts
+++ b/packages/@glimmer/component/addon/-private/destroyables.ts
@@ -1,0 +1,18 @@
+const DESTROYING = new WeakMap<object, boolean>();
+const DESTROYED = new WeakMap<object, boolean>();
+
+// TODO: remove once glimmer.js is updated to glimmer-vm 0.54.0+ and can use the destroyables API directly
+export function setDestroying(component: object) {
+  DESTROYING.set(component, true);
+}
+export function setDestroyed(component: object) {
+  DESTROYED.set(component, true);
+}
+
+export function isDestroying(component: object) {
+  return DESTROYING.has(component);
+}
+
+export function isDestroyed(component: object) {
+  return DESTROYED.has(component);
+}

--- a/packages/@glimmer/component/ember-addon-main.js
+++ b/packages/@glimmer/component/ember-addon-main.js
@@ -28,9 +28,31 @@ module.exports = {
       `
     );
 
+    let trees = [
+      tree,
+      ownerOverride,
+    ];
+
+    let checker = new VersionChecker(this.project);
+    let dep = checker.for('ember-source');
+
+    if (dep.gte('3.20.0-beta.4')) {
+      let destroyablesOverride = writeFile(
+        '-private/destroyables.ts',
+        `
+        import Ember from 'ember';
+
+        export const isDestroying = Ember.__loader.require('@glimmer/runtime').isDestroying;
+        export const isDestroyed = Ember.__loader.require('@glimmer/runtime').isDestroyed;
+      `
+      );
+
+      trees.push(destroyablesOverride);
+    }
+
     return this._super.treeForAddon.call(
       this,
-      new MergeTrees([tree, ownerOverride], {
+      new MergeTrees(trees, {
         overwrite: true,
       })
     );

--- a/packages/@glimmer/component/ember-addon-main.js
+++ b/packages/@glimmer/component/ember-addon-main.js
@@ -2,6 +2,7 @@
 
 const writeFile = require('broccoli-file-creator');
 const MergeTrees = require('broccoli-merge-trees');
+const VersionChecker = require('ember-cli-version-checker');
 
 module.exports = {
   name: '@glimmer/component',

--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -39,6 +39,7 @@
     "ember-cli-path-utils": "^1.0.0",
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-typescript": "3.0.0",
+    "ember-cli-version-checker": "^3.1.3",
     "ember-compatibility-helpers": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/@glimmer/component/src/component-manager.ts
+++ b/packages/@glimmer/component/src/component-manager.ts
@@ -2,7 +2,7 @@ import { capabilities, Bounds } from '@glimmer/application';
 import { setOwner, getOwner } from '@glimmer/di';
 
 import BaseComponentManager from '../addon/-private/base-component-manager';
-import { setDestroying, setDestroyed } from '../addon/-private/component';
+import { setDestroying, setDestroyed } from '../addon/-private/destroyables';
 import GlimmerComponent from './component';
 
 const CAPABILITIES = capabilities('3.13', {


### PR DESCRIPTION
Avoids deprecations for `Meta.prototype.setSourceDestroyed` and `Meta.prototype.setSourceDestroying` in Ember 3.20+.

Closes #292 
Closes https://github.com/emberjs/ember.js/issues/19042