### PR TITLE
feat: Throw better errors when upvars are missing

### DIFF
--- a/packages/@glimmer/core/src/render-component/resolvers.ts
+++ b/packages/@glimmer/core/src/render-component/resolvers.ts
@@ -85,6 +85,13 @@ export class CompileTimeResolver implements ResolverDelegate {
 
   lookupHelper(name: string, referrer: TemplateMeta): Option<number> {
     const scope = referrer.scope();
+
+    if (DEBUG && builtInHelpers[name] === undefined && scope[name] === undefined) {
+      throw new Error(
+        `Cannot find helper \`${name}\` in scope. It was used in a template, but not imported into the template scope.`
+      );
+    }
+
     const { helper, handle } =
       builtInHelpers[name] || vmDefinitionForHelper(scope[name] as HelperDefinition);
 
@@ -95,6 +102,12 @@ export class CompileTimeResolver implements ResolverDelegate {
   lookupModifier(name: string, referrer: TemplateMeta): Option<number> {
     const scope = referrer.scope();
     const modifier = scope[name] as ModifierDefinition;
+
+    if (DEBUG && modifier === undefined) {
+      throw new Error(
+        `Cannot find modifier \`${name}\` in scope. It was used in a template, but not imported into the template scope.`
+      );
+    }
 
     const definition = vmDefinitionForModifier(modifier);
     const { handle } = definition;

--- a/packages/@glimmer/core/test/non-interactive/strict-mode-test.ts
+++ b/packages/@glimmer/core/test/non-interactive/strict-mode-test.ts
@@ -69,5 +69,37 @@ if (DEBUG) {
         );
       }
     });
+
+    test('throws a helpful error if upvar is used as a helper', async (assert) => {
+      assert.expect(1);
+
+      try {
+        await render(createTemplate(`{{nope "yup"}}`));
+      } catch (err) {
+        assert.ok(
+          err
+            .toString()
+            .match(
+              /Cannot find helper `nope` in scope. It was used in a template, but not imported into the template scope or defined as a local variable./
+            )
+        );
+      }
+    });
+
+    test('throws a modifier error if upvar is used as a helper', async (assert) => {
+      assert.expect(1);
+
+      try {
+        await render(createTemplate(`<div {{nope "yup"}}></div>`));
+      } catch (err) {
+        assert.ok(
+          err
+            .toString()
+            .match(
+              /Cannot find modifier `nope` in scope. It was used in a template, but not imported into the template scope or defined as a local variable./
+            )
+        );
+      }
+    });
   });
 }


### PR DESCRIPTION
This adds more actionanle error messages to the `CompileTimeResolver`
for modifiers and helpers. Prior to this, you would end up getting
cryptic errors around using undefined to as key into a Weakmap.