### PR TITLE
Make @glimmer/tracking an ember-cli addon for Ember apps.

### DIFF
--- a/packages/@glimmer/tracking/ember-addon-main.js
+++ b/packages/@glimmer/tracking/ember-addon-main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  name: '@glimmer/tracking',
+};

--- a/packages/@glimmer/tracking/package.json
+++ b/packages/@glimmer/tracking/package.json
@@ -2,17 +2,25 @@
   "name": "@glimmer/tracking",
   "version": "2.0.0-beta.9",
   "description": "Glimmer property tracking library",
+  "keywords": [
+    "ember-addon"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/glimmerjs/glimmer.js",
+    "directory": "packages/@glimmer/tracking"
+  },
+  "license": "MIT",
   "contributors": [
     "Dan Gebhardt <dan@cerebris.com>",
     "Tom Dale <tom@tomdale.net>"
   ],
-  "repository": "https://github.com/glimmerjs/glimmer.js",
-  "license": "MIT",
-  "files": [
-    "dist"
-  ],
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "files": [
+    "dist",
+    "ember-addon-main.js"
+  ],
   "dependencies": {
     "@glimmer/env": "^0.1.7",
     "@glimmer/validator": "0.61.2"
@@ -23,6 +31,9 @@
     "@glimmer/interfaces": "0.61.2",
     "@glimmer/resolver": "^0.3.0",
     "@glimmer/wire-format": "0.61.2"
+  },
+  "ember-addon": {
+    "main": "ember-addon-main.js"
   },
   "volta": {
     "node": "12.16.1",


### PR DESCRIPTION
Today, when `@glimmer/tracking` is a dependency in an application (or addon) that also has a dependency on either `ember-auto-import` or is using Embroider the code that exists here for `@glimmer/tracking` is actually shipped in the main vendor.js bundle. This is _bad_ because that code is actually completely unused (since the babel transpilation will transform imports from `@glimmer/tracking` into `Ember` globals method calls).

The other issue is that Ember currently provides more capabilities from the `@glimmer/tracking` package than what is available to Glimmer.js users (for now): `@glimmer/tracking/primitives/cache`. Ember 3.22 adds built in support for these caching primitives and enables that import path to work properly.

Prior to these changes, attempting to import from `@glimmer/tracking/primtives/cache` would result in a build time resolution error:

```
Can't resolve '@glimmer/tracking/primitives/cache' in '/some/folder/name'
```

This works around the error by declaring that this package is an Ember addon, and it just happens to provide _no files_.

Fixes https://github.com/ember-polyfills/ember-cache-primitive-polyfill/issues/3