### PR TITLE
Add new option to output rehydratable markup from @glimmer/ssr

### DIFF
--- a/packages/@glimmer/core/src/render-component/index.ts
+++ b/packages/@glimmer/core/src/render-component/index.ts
@@ -14,6 +14,7 @@ import {
   EnvironmentOptions,
   WithStaticLayout,
   Environment,
+  ElementBuilder,
 } from '@glimmer/interfaces';
 import { artifacts } from '@glimmer/program';
 import { syntaxCompilationContext } from '@glimmer/opcode-compiler';
@@ -129,10 +130,11 @@ export function getTemplateIterator(
   envOptions: EnvironmentOptions,
   envDelegate: EnvironmentDelegate,
   componentArgs: Dict<unknown> = {},
-  owner = DEFAULT_OWNER
+  owner = DEFAULT_OWNER,
+  builderFactory: (env: Environment, cursor: GlimmerCursor) => ElementBuilder = clientBuilder
 ): { iterator: TemplateIterator; env: Environment } {
   const runtime = runtimeContext(envOptions, envDelegate, sharedArtifacts, resolver);
-  const builder = clientBuilder(runtime.env, {
+  const builder = builderFactory(runtime.env, {
     element,
     nextSibling: null,
   } as GlimmerCursor);

--- a/packages/@glimmer/ssr/src/render.ts
+++ b/packages/@glimmer/ssr/src/render.ts
@@ -6,8 +6,8 @@ import voidMap from '@simple-dom/void-map';
 import { PassThrough } from 'stream';
 import { parse } from 'url';
 import { BaseEnvDelegate } from '@glimmer/core';
-import { NodeDOMTreeConstruction } from '@glimmer/node';
-import { DOMChanges, renderSync } from '@glimmer/runtime';
+import { NodeDOMTreeConstruction, serializeBuilder } from '@glimmer/node';
+import { clientBuilder, DOMChanges, renderSync } from '@glimmer/runtime';
 
 /**
  * Server-side environment that can be used to configure the glimmer-vm to work
@@ -28,6 +28,7 @@ export interface RenderOptions {
   args?: Dict<unknown>;
   serializer?: HTMLSerializer;
   owner?: object;
+  rehydrate?: boolean;
 }
 
 const defaultSerializer = new HTMLSerializer(voidMap);
@@ -66,7 +67,8 @@ export function renderToStream(
     { appendOperations, updateOperations },
     new ServerEnvDelegate(),
     options.args,
-    options.owner
+    options.owner,
+    options.rehydrate ? serializeBuilder : clientBuilder
   );
   renderSync(env, iterator);
 

--- a/packages/@glimmer/ssr/test/render-options-tests.ts
+++ b/packages/@glimmer/ssr/test/render-options-tests.ts
@@ -23,4 +23,15 @@ QUnit.module('@glimmer/ssr rendering', () => {
 
     assert.equal(output, '<h1>Goodbye World</h1>');
   });
+
+  QUnit.test('setting rehydrate option outputs the block stacks', async (assert) => {
+    class MyComponent extends Component {}
+    setComponentTemplate(createTemplate(`<h1>Hello World</h1>`), MyComponent);
+    const output = await renderToString(MyComponent, { rehydrate: true });
+
+    assert.equal(
+      output,
+      '<!--%+b:0%--><!--%+b:1%--><h1>Hello World</h1><!--%-b:1%--><!--%-b:0%-->'
+    );
+  });
 });


### PR DESCRIPTION
**Why**
In order to support rehydration in glimmerjs we need to produce markup that contains the block stacks so that the rehydrate builder on the client can initialize correctly.

**How**
- Add a new top level render option `rehydrate`
- Add new option to `getTemplateIterator` to accept a custom builderFactory
- Swap to use the `serializeBuilder` if the `rehydrate` option is set
