### PR TITLE
Add new rehydrate option to renderComponent clientside api

### DIFF
--- a/packages/@glimmer/core/src/render-component/index.ts
+++ b/packages/@glimmer/core/src/render-component/index.ts
@@ -5,6 +5,7 @@ import {
   EnvironmentDelegate,
   DynamicScopeImpl,
   renderSync,
+  rehydrationBuilder,
 } from '@glimmer/runtime';
 import {
   Cursor as GlimmerCursor,
@@ -32,6 +33,7 @@ export interface RenderComponentOptions {
   element: Element;
   args?: Dict<unknown>;
   owner?: object;
+  rehydrate?: boolean;
 }
 
 type ResolveFn = () => void;
@@ -72,7 +74,8 @@ async function renderComponent(
     { document },
     new ClientEnvDelegate(),
     args,
-    owner
+    owner,
+    options.rehydrate ? rehydrationBuilder : clientBuilder
   );
   const result = renderSync(env, iterator);
   results.push(result);

--- a/packages/@glimmer/core/test/interactive/render-test.ts
+++ b/packages/@glimmer/core/test/interactive/render-test.ts
@@ -34,4 +34,17 @@ module(`[@glimmer/core] interactive rendering tests`, () => {
 
     assert.equal(containerElement.innerHTML, '<p>foo</p>bar<h1>Hello Glimmer!</h1>');
   });
+
+  test('rehydrates a component from existing markup when rehydrate option is set', async (assert) => {
+    const containerElement = document.createElement('div');
+    containerElement.innerHTML =
+      '<!--%+b:0%--><!--%+b:1%--><h1>Hello World</h1><!--%-b:1%--><!--%-b:0%-->';
+
+    await render(createTemplate(`<h1>Hello World</h1>`), {
+      element: containerElement,
+      rehydrate: true,
+    });
+
+    assert.equal(containerElement.innerHTML, '<h1>Hello World</h1>');
+  });
 });


### PR DESCRIPTION
**Why**
When rehydrating the server producing output containing the block stacks. On the client side we need to use the rehydrationBuilder instead of the clientBuilder so that we don't replace/append to the existing markup produced from the server

**How**
- Add new top level `rehydrate` option to the renderComponent API
- Use rehydrationBuilder when that option is set