### PR TITLE
Ensure stability of destroyable APIs in Ember 3.22+.

### DIFF
--- a/packages/@glimmer/component/addon/-private/destroyables.ts
+++ b/packages/@glimmer/component/addon/-private/destroyables.ts
@@ -1,3 +1,6 @@
+// NOTE: DO NOT MODIFY
+//
+// This module is clobbered by ember-addon-main when used in Ember >= 3.20.0-beta.4
 const DESTROYING = new WeakMap<object, boolean>();
 const DESTROYED = new WeakMap<object, boolean>();
 

--- a/packages/@glimmer/component/addon/-private/ember-component-manager.ts
+++ b/packages/@glimmer/component/addon/-private/ember-component-manager.ts
@@ -38,8 +38,7 @@ const scheduledDestroyComponent = gte('3.20.0-beta.4')
   };
 
 const destroy = gte('3.20.0-beta.4')
-  // @ts-ignore
-  ? Ember.__loader.require('@glimmer/runtime').destroy
+  ? Ember.destroy
   : (component:  GlimmerComponent) => {
     if (component.isDestroying) {
       return;
@@ -55,7 +54,10 @@ const destroy = gte('3.20.0-beta.4')
   };
 
 
-const registerDestructor = gte('3.20.0-beta.4')
+const registerDestructor = gte('3.22.0-beta')
+  // @ts-ignore
+  ? Ember._registerDestructor
+  : gte('3.20.0-beta.4')
   // @ts-ignore
   ? Ember.__loader.require('@glimmer/runtime').registerDestructor
   : undefined;

--- a/packages/@glimmer/component/ember-addon-main.js
+++ b/packages/@glimmer/component/ember-addon-main.js
@@ -37,7 +37,22 @@ module.exports = {
     let checker = new VersionChecker(this.project);
     let dep = checker.for('ember-source');
 
-    if (dep.gte('3.20.0-beta.4')) {
+    // Ember shipped public API directly, this is more likely to be stable over time
+    if (dep.gte('3.22.0-beta.1')) {
+      let destroyablesOverride = writeFile(
+        '-private/destroyables.ts',
+        `
+        import Ember from 'ember';
+
+        export const isDestroying = Ember._isDestroying;
+        export const isDestroyed = Ember._isDestroyed;
+      `
+      );
+
+      trees.push(destroyablesOverride);
+    } else if (dep.gte('3.20.0-beta.4')) {
+      // using internals to access from `@glimmer/runtime`
+
       let destroyablesOverride = writeFile(
         '-private/destroyables.ts',
         `


### PR DESCRIPTION
In Ember 3.20 and 3.21 the official `isDestroying` and `isDestroyable` APIs were not published so we reached into the `@glimmer/runtime` internals.

In the meantime, the actual location of the destroyable implementation has changed from `@glimmer/runtime` to `@glimmer/destroyable` (on Ember 3.25's canary cycle). This has lead to a number of failures for folks that are testing against those canary builds.

This commit changes the implementation to use Ember's own official public API location for `isDestroying`/`isDestroyed` when using Ember 3.22+ (which nicely absorbs the issue for 3.25 canary users, and guarantees some additional level of stability).
