### PR TITLE
fix invalid imports

### DIFF
--- a/packages/@glimmer/component/addon/-private/ember-component-manager.ts
+++ b/packages/@glimmer/component/addon/-private/ember-component-manager.ts
@@ -11,7 +11,8 @@ import BaseComponentManager, {
 } from './base-component-manager';
 
 import GlimmerComponent, { Constructor } from './component';
-import { setDestroyed, setDestroying } from './destroyables';
+import * as destroyables from './destroyables';
+const { setDestroyed, setDestroying } = destroyables;
 
 const CAPABILITIES = gte('3.13.0-beta.1')
   ? capabilities('3.13', {


### PR DESCRIPTION
This fixes https://github.com/glimmerjs/glimmer.js/issues/316.

That issue turns out to be more than an annoyance for Embroider's auditing code. As I'm experimenting with alternative packagers, I'm finding others that blow up because of the invalid use of imports here.