### PR TITLE
Ensure @glimmer/babel-preset is usable in browsers

### DIFF
--- a/packages/@glimmer/babel-preset/package.json
+++ b/packages/@glimmer/babel-preset/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-decorators": "^7.8.3",
-    "@glimmer/compiler": "0.77.5",
-    "@glimmer/vm-babel-plugins": "0.77.5",
+    "@glimmer/compiler": "0.77.6",
+    "@glimmer/vm-babel-plugins": "0.77.6",
     "babel-plugin-debug-macros": "^0.3.4",
     "babel-plugin-htmlbars-inline-precompile": "^5.2.0"
   },

--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@glimmer/env": "^0.1.7",
-    "@glimmer/util": "0.77.5",
+    "@glimmer/util": "0.77.6",
     "@glimmer/core": "2.0.0-beta.14",
     "broccoli-file-creator": "^2.1.1",
     "broccoli-merge-trees": "^3.0.2",
@@ -43,11 +43,11 @@
   "devDependencies": {
     "@ember/optional-features": "^0.6.1",
     "@glimmer/application-test-helpers": "^1.0.0",
-    "@glimmer/compiler": "0.77.5",
-    "@glimmer/interfaces": "0.77.5",
+    "@glimmer/compiler": "0.77.6",
+    "@glimmer/interfaces": "0.77.6",
     "@glimmer/resolver": "^0.3.0",
     "@glimmer/tracking": "2.0.0-beta.14",
-    "@glimmer/wire-format": "0.77.5",
+    "@glimmer/wire-format": "0.77.6",
     "@types/ember": "~3.0.29",
     "@types/ember-qunit": "~3.4.3",
     "@types/ember-test-helpers": "~1.0.6",

--- a/packages/@glimmer/core/package.json
+++ b/packages/@glimmer/core/package.json
@@ -13,18 +13,18 @@
   },
   "dependencies": {
     "@glimmer/env": "^0.1.7",
-    "@glimmer/global-context": "0.77.5",
-    "@glimmer/interfaces": "0.77.5",
-    "@glimmer/manager": "0.77.5",
-    "@glimmer/opcode-compiler": "0.77.5",
-    "@glimmer/owner": "0.77.5",
-    "@glimmer/program": "0.77.5",
-    "@glimmer/runtime": "0.77.5",
-    "@glimmer/validator": "0.77.5",
+    "@glimmer/global-context": "0.77.6",
+    "@glimmer/interfaces": "0.77.6",
+    "@glimmer/manager": "0.77.6",
+    "@glimmer/opcode-compiler": "0.77.6",
+    "@glimmer/owner": "0.77.6",
+    "@glimmer/program": "0.77.6",
+    "@glimmer/runtime": "0.77.6",
+    "@glimmer/validator": "0.77.6",
     "@simple-dom/interface": "^1.4.0"
   },
   "devDependencies": {
-    "@glimmer/compiler": "0.77.5",
+    "@glimmer/compiler": "0.77.6",
     "@glimmer/component": "2.0.0-beta.14",
     "@glimmer/tracking": "2.0.0-beta.14"
   },

--- a/packages/@glimmer/debug/package.json
+++ b/packages/@glimmer/debug/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@glimmer/global-context": "0.77.5"
+    "@glimmer/global-context": "0.77.6"
   },
   "volta": {
     "node": "12.16.1",

--- a/packages/@glimmer/helper/package.json
+++ b/packages/@glimmer/helper/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@glimmer/component": "2.0.0-beta.14",
     "@glimmer/core": "2.0.0-beta.14",
-    "@glimmer/runtime": "0.77.5"
+    "@glimmer/runtime": "0.77.6"
   },
   "volta": {
     "node": "12.16.1",

--- a/packages/@glimmer/modifier/package.json
+++ b/packages/@glimmer/modifier/package.json
@@ -12,7 +12,7 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/runtime": "0.77.5"
+    "@glimmer/runtime": "0.77.6"
   },
   "volta": {
     "node": "12.16.1",

--- a/packages/@glimmer/ssr/package.json
+++ b/packages/@glimmer/ssr/package.json
@@ -11,10 +11,10 @@
   "module": "dist/modules/index.js",
   "dependencies": {
     "@glimmer/core": "2.0.0-beta.14",
-    "@glimmer/node": "0.77.5",
-    "@glimmer/reference": "0.77.5",
-    "@glimmer/runtime": "0.77.5",
-    "@glimmer/util": "0.77.5",
+    "@glimmer/node": "0.77.6",
+    "@glimmer/reference": "0.77.6",
+    "@glimmer/runtime": "0.77.6",
+    "@glimmer/util": "0.77.6",
     "@simple-dom/document": "^1.4.0",
     "@simple-dom/serializer": "^1.4.0",
     "@simple-dom/void-map": "^1.4.0"

--- a/packages/@glimmer/tracking/package.json
+++ b/packages/@glimmer/tracking/package.json
@@ -23,14 +23,14 @@
   ],
   "dependencies": {
     "@glimmer/env": "^0.1.7",
-    "@glimmer/validator": "0.77.5"
+    "@glimmer/validator": "0.77.6"
   },
   "devDependencies": {
     "@glimmer/application-test-helpers": "^1.0.0",
-    "@glimmer/compiler": "0.77.5",
-    "@glimmer/interfaces": "0.77.5",
+    "@glimmer/compiler": "0.77.6",
+    "@glimmer/interfaces": "0.77.6",
     "@glimmer/resolver": "^0.3.0",
-    "@glimmer/wire-format": "0.77.5"
+    "@glimmer/wire-format": "0.77.6"
   },
   "ember-addon": {
     "main": "ember-addon-main.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,15 +1015,15 @@
     "@glimmer/util" "^0.44.0"
     "@glimmer/wire-format" "^0.44.0"
 
-"@glimmer/compiler@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.77.5.tgz#f12cf9cff8b8a8c94e8edffa6f967caf3ff92776"
-  integrity sha512-WXNfEtqmoAur2+aU0qZnE1cK6GVucwUlCHJd6756FrFxTcayl/Zj6+Ti5yfTSnqXnYo2rRWn0FCc/WZ0wGlTGw==
+"@glimmer/compiler@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.77.6.tgz#010ca57c3031071ef317181c6f8ecba71526101f"
+  integrity sha512-kfaLoqypiyL08KmmIIIsuR9wZP2EWnF/aHvusAVp8o578w2Veseba1tr7p/1fkY9TsC+su9A0g+KXZ3EoKrWpA==
   dependencies:
-    "@glimmer/interfaces" "0.77.5"
-    "@glimmer/syntax" "0.77.5"
-    "@glimmer/util" "0.77.5"
-    "@glimmer/wire-format" "0.77.5"
+    "@glimmer/interfaces" "0.77.6"
+    "@glimmer/syntax" "0.77.6"
+    "@glimmer/util" "0.77.6"
+    "@glimmer/wire-format" "0.77.6"
     "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/compiler@^0.44.0":
@@ -1036,15 +1036,15 @@
     "@glimmer/util" "^0.44.0"
     "@glimmer/wire-format" "^0.44.0"
 
-"@glimmer/destroyable@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/destroyable/-/destroyable-0.77.5.tgz#c55089f2007a42a59058784d75b30784ed138bc7"
-  integrity sha512-s8cVbb+WlE6tTpwRhzOhlwO9PSokjC3s7wzkD6gHCQIPQivc8BHqZ2czUWfQFhHZdYVk4dg04pFMq+y8m3qC0Q==
+"@glimmer/destroyable@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/destroyable/-/destroyable-0.77.6.tgz#5e83739a53025ad4d68a5be55379fdb3ab3dbb35"
+  integrity sha512-3SqfWPg+P2u2sjmLhL7jc8vpo4Z2pgS4D4/LOUW8Y0CW0mxAr49HoTGh6qWGHs1baAVy1HGc/ZlaTxMKhpBjJQ==
   dependencies:
     "@glimmer/env" "0.1.7"
-    "@glimmer/global-context" "0.77.5"
-    "@glimmer/interfaces" "0.77.5"
-    "@glimmer/util" "0.77.5"
+    "@glimmer/global-context" "0.77.6"
+    "@glimmer/interfaces" "0.77.6"
+    "@glimmer/util" "0.77.6"
 
 "@glimmer/di@^0.1.9":
   version "0.1.11"
@@ -1056,14 +1056,14 @@
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.1.tgz#5286b6b32040232b751138f6d006130c728d4b3d"
   integrity sha512-0D53YVuEgGdHfTl9LGWDZqVzGhn4cT0CXqyAuOYkKFLvqboJXz6SnkRhQNPhhA2hLVrPnvUz3+choQmPhHLGGQ==
 
-"@glimmer/encoder@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.77.5.tgz#40dd91417998c7f1c6b1fa947fa881a598250bc3"
-  integrity sha512-BJpuFi78T9U8g5ix5R99kYhB4m5hQRfB0femrvGhECyhtOZJ+Y797uuOaSqmGTYTY8VIhvxEao6YRaKly0K3mw==
+"@glimmer/encoder@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.77.6.tgz#d0e29e9aefce0a259d1142497e3a37086b480c04"
+  integrity sha512-qqkWinPfD0nf0dkIzp1BcD2wHXZ63kbDDwU/5LZxr10k9xb+BPSmZRVU+sUh9ilD23Zwj3IFbsNGxLaYFf6yRw==
   dependencies:
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "0.77.5"
-    "@glimmer/vm" "0.77.5"
+    "@glimmer/interfaces" "0.77.6"
+    "@glimmer/vm" "0.77.6"
 
 "@glimmer/encoder@^0.44.0":
   version "0.44.0"
@@ -1078,17 +1078,17 @@
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
 
-"@glimmer/global-context@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/global-context/-/global-context-0.77.5.tgz#ff72f216cd39f7e7923d54f3bb0862910070a9cc"
-  integrity sha512-kWHYjOyhYeyBEEuu3gMJsLO9WxFlXFFeWmtk2raWkJ37TndZNUFMQt6C0yOyT/AkXUJH5+1W7XSia1P3TB6CKw==
+"@glimmer/global-context@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/global-context/-/global-context-0.77.6.tgz#8b2c62bf31996dea8659c5128f8c05a96bc73e65"
+  integrity sha512-ev2ZH5Qz35mh6GAanM758ghZisGRIPbf6vmZuZbn/xiR2zDZIVRN5vMqSOsGs2lI+UKZ1qZWnTPa04wDS+lybQ==
   dependencies:
     "@glimmer/env" "^0.1.7"
 
-"@glimmer/interfaces@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.77.5.tgz#74c791ba4712588f2e7b65669d90e8d349eee30a"
-  integrity sha512-ahiZX2EG2w1DrXmIxjzmkRrAeRJS+y35YTXhP82/NSyLiS2g7NTgYbqXpsS+VfvYRZ2+EbeXzY7cTe8mN4OUxg==
+"@glimmer/interfaces@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.77.6.tgz#e11715bcdc5c5133cbb52db9a53b16c49ee611e5"
+  integrity sha512-VVsi6Z8BgV9Y42FSybiImb6BR00ILr5m5M0B2VbDFytuKR0scRf0xUzKQV+EgLXOwgu/L5XVQJMWElYxTh6xBw==
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
@@ -1097,70 +1097,70 @@
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.44.0.tgz#0896204815f05fd8907b5703cbaee9d1b9edf5d3"
   integrity sha512-O1VBrB1uhWh/XpBRaMbT5zncZiJJNTAqe0rnhRr4JicrlmNoIC4/5ADRgDORj5oBxuENjuZ+6UTul3WCOHETiw==
 
-"@glimmer/low-level@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.77.5.tgz#f198acd9c6b5f39da07756db32f11cf0f8714f7e"
-  integrity sha512-A+bNz17vBcTe0qn38q0sdDldCj4gKdFllw8lRHms2Xn50xc+e0uQ00sFFVBT51XDrKiX6u+U72sVnBrUYCbGXg==
+"@glimmer/low-level@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.77.6.tgz#76966084d2d80c7a586c3a4fcd6389e78b4d141e"
+  integrity sha512-7L66cjGqBBiHYu5D2cLz9Tvo2wo6EzTpV3jbNziLhiLIEjfg9lzy6HaE6IR4/osIbOiwtvEU6ZGrwoM/vbx4zg==
 
 "@glimmer/low-level@^0.44.0":
   version "0.44.0"
   resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.44.0.tgz#c164efc7e946d7cbbe54c258e64b9148e971c871"
   integrity sha512-qOayju1J3vpQUT21QxafbP/7EIxY0ve5B9Biyk3i9MCb1BRnTL2OPoNK7Ia5uuA8qbwIk/PuNqx+uHYoOipXMw==
 
-"@glimmer/manager@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/manager/-/manager-0.77.5.tgz#dfbd94a2f47640f8d6fcdf67bb8cc8e995c835f8"
-  integrity sha512-neURL3qGaDuiq/8YYE4F2reGnS42vMjgYcJjP00eY/pBHfOY6icPR1oPwGmTt8Qr6topGc3FmUaUWDXPt0Lnkg==
+"@glimmer/manager@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/manager/-/manager-0.77.6.tgz#c6f28ec2084da7e690139936d783405524316a0d"
+  integrity sha512-Izb/4pRNTEyuqIUY1kfV4GDG5ki2VKIEw4pBvHcfeKoxqXGWEIR8rmG2Maghbbsn41qX0tjGI7K5bruvUVgDtg==
   dependencies:
-    "@glimmer/destroyable" "0.77.5"
+    "@glimmer/destroyable" "0.77.6"
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "0.77.5"
-    "@glimmer/reference" "0.77.5"
-    "@glimmer/util" "0.77.5"
-    "@glimmer/validator" "0.77.5"
+    "@glimmer/interfaces" "0.77.6"
+    "@glimmer/reference" "0.77.6"
+    "@glimmer/util" "0.77.6"
+    "@glimmer/validator" "0.77.6"
 
-"@glimmer/node@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.77.5.tgz#6bb693744d612a770d106b69d2803c2423c15868"
-  integrity sha512-BBM32C5GldOFxUbV2XljwoNmOGP9YobJF9WEW1zVkbggDZcGH090VwbTErrXVv8aw987fGXqei0UCFGleOXu1A==
+"@glimmer/node@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.77.6.tgz#fd3661d88532c46fc7a8f5c45b0a4be1e5d3a318"
+  integrity sha512-C6CMJ75mGavJ+gqMOxSadXG3Gxq/CdUKhPgeT3T5X3WgHzyyiR9cBS28xeOZ8IT1ryWGAFCd2fqmj8IhLC+GUQ==
   dependencies:
-    "@glimmer/interfaces" "0.77.5"
-    "@glimmer/runtime" "0.77.5"
-    "@glimmer/util" "0.77.5"
+    "@glimmer/interfaces" "0.77.6"
+    "@glimmer/runtime" "0.77.6"
+    "@glimmer/util" "0.77.6"
     "@simple-dom/document" "^1.4.0"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/opcode-compiler@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.77.5.tgz#088f946587c905fcb37a6516df5cb858fc177d7c"
-  integrity sha512-qJYdDeJFch2BGpYWmZ0klExsBvu6bZYoNyRtzUmuA0+xzT2I1HdwrTpekkAHVDfB0rfHArHmcimTxgFF15o4Mg==
+"@glimmer/opcode-compiler@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.77.6.tgz#018c196e406e8f1780fc8d8609d6d63c2f4b5372"
+  integrity sha512-oehFnYkV4g9CbMMxpXxuKkeLO/WyL2gnMEKy+wpwqoOX3fOSljt6zzngCX/3NOTbD6ZZNEtXUvV8hx0pISJ8cw==
   dependencies:
-    "@glimmer/encoder" "0.77.5"
+    "@glimmer/encoder" "0.77.6"
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "0.77.5"
-    "@glimmer/reference" "0.77.5"
-    "@glimmer/util" "0.77.5"
-    "@glimmer/vm" "0.77.5"
-    "@glimmer/wire-format" "0.77.5"
+    "@glimmer/interfaces" "0.77.6"
+    "@glimmer/reference" "0.77.6"
+    "@glimmer/util" "0.77.6"
+    "@glimmer/vm" "0.77.6"
+    "@glimmer/wire-format" "0.77.6"
 
-"@glimmer/owner@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/owner/-/owner-0.77.5.tgz#d81933f3d6c4c0feafcf3d972cc7edca00532a5b"
-  integrity sha512-0jPDb63qBNN20QkVprIuennHP1Vf3fWCQNtuVOYsDOjyV2RIlrOwTVLuFIpua86nSBRQq7gH411ZyEpoq6H3Cg==
+"@glimmer/owner@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/owner/-/owner-0.77.6.tgz#22cc9f5f0867387b1abd2576fc8eb79c0dadecd7"
+  integrity sha512-w2vS7mHaj/3J1U5KzgsgGn3W15WuxqAvqp02SyxmDgkZedJQm0UGxadWdxepCnNgTby5E+cqkTVf7LZo+HTqng==
   dependencies:
-    "@glimmer/util" "0.77.5"
+    "@glimmer/util" "0.77.6"
 
-"@glimmer/program@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.77.5.tgz#53ce8da78377b255a22eb1d86eb5e6a837393305"
-  integrity sha512-19rWpeqqK7UF6CT9G+A7TOnWeoIlT8wCF4gKQNRbp2sbUugJ0PyTn7VzZTLAc110F0ohFlv17yKIrDBoPytHDw==
+"@glimmer/program@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.77.6.tgz#7e1fdc1efda89d39ce7b532dc10edc70ce29cd78"
+  integrity sha512-2Y8YSBF+SJsMMEo/0aThv+38MuLzlGYBkafkN/vMhOm+T4K2e7nAO7JkQyihBktRQOAUD97RetNTnsVLaZqvzg==
   dependencies:
-    "@glimmer/encoder" "0.77.5"
+    "@glimmer/encoder" "0.77.6"
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "0.77.5"
-    "@glimmer/manager" "0.77.5"
-    "@glimmer/opcode-compiler" "0.77.5"
-    "@glimmer/util" "0.77.5"
+    "@glimmer/interfaces" "0.77.6"
+    "@glimmer/manager" "0.77.6"
+    "@glimmer/opcode-compiler" "0.77.6"
+    "@glimmer/util" "0.77.6"
 
 "@glimmer/program@^0.44.0":
   version "0.44.0"
@@ -1171,16 +1171,16 @@
     "@glimmer/interfaces" "^0.44.0"
     "@glimmer/util" "^0.44.0"
 
-"@glimmer/reference@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.77.5.tgz#54eac6b00bd06cb84ff8c9f854d9a7811f2c298f"
-  integrity sha512-L432i/VD4Kud8qsvPs3bY12hjkKOjfqH1tyGnjfdNAip/k6Z7GIuFDi+T/lJOLWLFONh4414KDopTysBXx9USw==
+"@glimmer/reference@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.77.6.tgz#377780f35dd63861c083e9038c2715651e6fd8cc"
+  integrity sha512-AHkccjgI/oa0YZkl4WMIjgvVM4fFmK8mZtXFaH48P/LSluE2QBIZvMINxUJ5qC7B5JASSacwxf7MsaePVSzDpA==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/global-context" "0.77.5"
-    "@glimmer/interfaces" "0.77.5"
-    "@glimmer/util" "0.77.5"
-    "@glimmer/validator" "0.77.5"
+    "@glimmer/global-context" "0.77.6"
+    "@glimmer/interfaces" "0.77.6"
+    "@glimmer/util" "0.77.6"
+    "@glimmer/validator" "0.77.6"
 
 "@glimmer/reference@^0.44.0":
   version "0.44.0"
@@ -1204,23 +1204,23 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
-"@glimmer/runtime@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.77.5.tgz#6b936da4e2f37cd3994626efa672b15c715ae0f8"
-  integrity sha512-rLzXY2IFw7yzsvOwy/3eLxoza9Y9vx52bivlZJ9+8AWCtn4ywNGOKwvv4i8Mf1EMXtvo3nZHC9yIwfpUJg8NLg==
+"@glimmer/runtime@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.77.6.tgz#3be182e14dc7109433b29eb7958d2cd26e4cbf87"
+  integrity sha512-rfT3Rvy1MNsOTR8axZffmrOBn1hqg7jO43OEjnc1fkg0P6EjJpEqze9/hhkCnV3vwS9m2TenWiC3e6dqeb10rg==
   dependencies:
-    "@glimmer/destroyable" "0.77.5"
+    "@glimmer/destroyable" "0.77.6"
     "@glimmer/env" "0.1.7"
-    "@glimmer/global-context" "0.77.5"
-    "@glimmer/interfaces" "0.77.5"
-    "@glimmer/low-level" "0.77.5"
-    "@glimmer/owner" "0.77.5"
-    "@glimmer/program" "0.77.5"
-    "@glimmer/reference" "0.77.5"
-    "@glimmer/util" "0.77.5"
-    "@glimmer/validator" "0.77.5"
-    "@glimmer/vm" "0.77.5"
-    "@glimmer/wire-format" "0.77.5"
+    "@glimmer/global-context" "0.77.6"
+    "@glimmer/interfaces" "0.77.6"
+    "@glimmer/low-level" "0.77.6"
+    "@glimmer/owner" "0.77.6"
+    "@glimmer/program" "0.77.6"
+    "@glimmer/reference" "0.77.6"
+    "@glimmer/util" "0.77.6"
+    "@glimmer/validator" "0.77.6"
+    "@glimmer/vm" "0.77.6"
+    "@glimmer/wire-format" "0.77.6"
     "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/runtime@^0.44.0":
@@ -1237,13 +1237,13 @@
     "@glimmer/vm" "^0.44.0"
     "@glimmer/wire-format" "^0.44.0"
 
-"@glimmer/syntax@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.77.5.tgz#b841803dd54ea86de7e8ae8850b3760000033bf2"
-  integrity sha512-FRb1onDsP9P2CnbwTyKF91QYIbRJ0svALG7TnAJlUjQU9E4lWdI5lf7vPRh45A4W1rjcAcIcuiIS6oGrdEkhuQ==
+"@glimmer/syntax@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.77.6.tgz#31142ba914ee123f9b5e5c70bd92272cb6258bca"
+  integrity sha512-Nh5D/IGpY7LQ5fmNEIeU9UdwIb9xaRfEefsSbIiBcHw13mauFVz7K+ZKIn3p1Qur6xWmUIKcYgXCAsOFFiOyQg==
   dependencies:
-    "@glimmer/interfaces" "0.77.5"
-    "@glimmer/util" "0.77.5"
+    "@glimmer/interfaces" "0.77.6"
+    "@glimmer/util" "0.77.6"
     "@handlebars/parser" "~2.0.0"
     simple-html-tokenizer "^0.5.10"
 
@@ -1257,13 +1257,13 @@
     handlebars "^4.5.1"
     simple-html-tokenizer "^0.5.8"
 
-"@glimmer/util@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.77.5.tgz#b4e2909d34eb7db34c63fd9d942e0ffa458d4c90"
-  integrity sha512-Y78NnJClpz7sBks3q+ZNNVfCjy8ALcCQOG5GEIm/P9O3+eXMBsx2ac9Umu4LBZqmeINQ9CtFz10u2BiyxOtSQg==
+"@glimmer/util@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.77.6.tgz#4997f9a066aab915f50c344b2aedab8108b4658b"
+  integrity sha512-IjrVvSv8fPCroyWHFaJO4q0iIy5s8Zge0PgghrI7Z4Ne5bKHifODy/6yAnA1EjE1NhHAVlZbHjI/pE17a+VjoA==
   dependencies:
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "0.77.5"
+    "@glimmer/interfaces" "0.77.6"
     "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/util@^0.44.0":
@@ -1271,33 +1271,33 @@
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.44.0.tgz#45df98d73812440206ae7bda87cfe04aaae21ed9"
   integrity sha512-duAsm30uVK9jSysElCbLyU6QQYO2X9iLDLBIBUcCqck9qN1o3tK2qWiHbGK5d6g8E2AJ4H88UrfElkyaJlGrwg==
 
-"@glimmer/validator@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.77.5.tgz#a5e272d700f661aa0b2f350670974792b7785a49"
-  integrity sha512-LluyvxWTqys5ulkYA24sFDQ/obwOTwbLDakNBOlHvKdh814h+scz4y8bckx6qY7AsJObQgZVAg00r1Nlhfs6fQ==
+"@glimmer/validator@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.77.6.tgz#1271a344f2249e2835869dc3cacd91aaa9a7dda0"
+  integrity sha512-ZybFdN3Oc/qzwPNsu7GOf+9FylJyVv+QqGcXeE+eN5wkwv5RxhUZxpo+vdag47r6MVfsZvQlsbmGndwr5LkGjw==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/global-context" "0.77.5"
+    "@glimmer/global-context" "0.77.6"
 
 "@glimmer/validator@^0.44.0":
   version "0.44.0"
   resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
   integrity sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==
 
-"@glimmer/vm-babel-plugins@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.77.5.tgz#daffb6507aa6b08ec36f69d652897d339fdd0007"
-  integrity sha512-jTBM7fJMrIEy4/bCeI8e7ypR+AuWYzLA+KORCGbnTJtL/NYg4G8qwhQAZBtg1d3KmoqyqaCsyqE6f4/tzJO4eQ==
+"@glimmer/vm-babel-plugins@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.77.6.tgz#e74d61884e44c0d0db34bef78514ac37c0fc0d6f"
+  integrity sha512-oSAhYfAS4A6xDTAdY6mDDgxfcTyb4Cgm6SphKcrTBecpz2TaKRbTMdg8K6slI8n2sj5KDeBpXHPrPBYHoYtGHQ==
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
 
-"@glimmer/vm@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.77.5.tgz#ff244acb0ce4a0076df01da8fdd37d690833e478"
-  integrity sha512-SsG/BEnM+ySk236UlHHoxYufdWwMSmr2RiapQp6O4pDzy7npkRebTYOzXCXpYrFkjDcTwPaygYCnr7RRFJXEUA==
+"@glimmer/vm@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.77.6.tgz#8bfaed24797ba302f574fac838022ba1161e9f4e"
+  integrity sha512-OONfuQcl9QlRcendwZB7zcTnClousOBdFmCH56wI4CM5/EBwNbCYxEnFYaqRvJcOrWrRwGjF6+ubAnDLEbUfRw==
   dependencies:
-    "@glimmer/interfaces" "0.77.5"
-    "@glimmer/util" "0.77.5"
+    "@glimmer/interfaces" "0.77.6"
+    "@glimmer/util" "0.77.6"
 
 "@glimmer/vm@^0.44.0":
   version "0.44.0"
@@ -1307,13 +1307,13 @@
     "@glimmer/interfaces" "^0.44.0"
     "@glimmer/util" "^0.44.0"
 
-"@glimmer/wire-format@0.77.5":
-  version "0.77.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.77.5.tgz#326ae0e09d81182096c0e4efef7cc197d96081d4"
-  integrity sha512-/FyjStQtyHkCS8dOp7t79e+PIgEAF0yo9rxmazexl3Ie3ePE9qRxOQi/GKIxi1V1YGpxxv8Aq6wP8kteUzCDaQ==
+"@glimmer/wire-format@0.77.6":
+  version "0.77.6"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.77.6.tgz#d3a1a9e27c16c9c89f48cd8500f36960dd648325"
+  integrity sha512-VjLlPbuuyWnkzbvibm9PGbhBbAnx+Hrc3jS/x9Av1P7JKXlKMeJIijYrnWrfdC/3TltbVuuwNo3fBCoShWwqQg==
   dependencies:
-    "@glimmer/interfaces" "0.77.5"
-    "@glimmer/util" "0.77.5"
+    "@glimmer/interfaces" "0.77.6"
+    "@glimmer/util" "0.77.6"
 
 "@glimmer/wire-format@^0.44.0":
   version "0.44.0"


### PR DESCRIPTION
Currently, attempting to use `@glimmer/babel-preset` in browsers with
standard build tooling fails due to the dynamic `require` that Babel
itself does with the resolved paths. This change adds an option that
allows us to load the plugins directly, which means that they will be
bundled properly.