### PR TITLE
Fix internal setComponentManager type

### DIFF
--- a/packages/@glimmer/component/addon/index.ts
+++ b/packages/@glimmer/component/addon/index.ts
@@ -5,7 +5,7 @@ import ApplicationInstance from '@ember/application/instance';
 declare module '@ember/component' {
   export function setComponentManager<T extends object>(
     factory: (owner: ApplicationInstance) => GlimmerComponentManager,
-    T
+    componentClass: T
   ): T;
 }
 


### PR DESCRIPTION
Minor TS fix: `T` was used as an argument *name*, instead of its *type*.