### PR TITLE
Add API Usage docs to @glimmer/ssr

### DIFF
--- a/packages/@glimmer/ssr/README.md
+++ b/packages/@glimmer/ssr/README.md
@@ -1,0 +1,30 @@
+# API Usage
+
+```js
+import { setComponentTemplate } from '@glimmer/core';
+import component from '@glimmer/component';
+import { renderToString } from '@glimmer/ssr';
+
+import { templateFactory } from '@glimmer/opcode-compiler';
+import { precompile } from '@glimmer/compiler';
+
+let GlimmerComponent = component.default;
+
+class PageComponent extends GlimmerComponent {}
+
+let template = `
+  {{#let "hello" "world" as |hello world|}}<p>{{hello}} {{world}}</p>{{/let}}
+`;
+
+setComponentTemplate(
+  templateFactory(JSON.parse(precompile(template, { strictMode: true }))),
+  PageComponent
+);
+
+// Print <p>hello world</p> to console:
+console.log(await renderToString(PageComponent, {
+  owner: {
+    services: {}
+  },
+}));
+```


### PR DESCRIPTION
This documentation might be helpful for others trying to figure out how this works, it will show up in the npm after a new release.

I still haven't figured out how to embed components inside component scopes, still trying to figure out how.  

The code below doesn't work for template imports/component composition(fixed in other comments below):
```js
import { setComponentTemplate } from '@glimmer/core';
import component from '@glimmer/component';
import { renderToString } from '@glimmer/ssr';

import { templateFactory } from '@glimmer/opcode-compiler';
import { precompile } from '@glimmer/compiler';

let GlimmerComponent = component.default;

class AnotherComponent extends GlimmerComponent {}
setComponentTemplate(
  templateFactory(JSON.parse(
    precompile(`<h5>This is another component</h5>`, { strictMode: true }))
  ),
  AnotherComponent
);

class PageComponent extends GlimmerComponent {}
setComponentTemplate(
  templateFactory(JSON.parse(
    precompile(`
      {{#let "hello" "world" as |hello world|}}<p>{{hello}} {{world}}</p>{{/let}}
      <AnotherComponent />
    `, {
      strictMode: true,
      scope: () => {
        return { AnotherComponent };
      }
    }))
  ),
  PageComponent
);

console.log(await renderToString(PageComponent, {
  owner: {
    services: {
    },
  },
}));
```