### PR TITLE
Drop support for Node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10, 12, 13]
+        node-version: [12, 13]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 13]
+        node-version: [12, 14, 16]
 
     steps:
       - uses: actions/checkout@v2

--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -84,7 +84,7 @@
     "typescript": "~3.8.2"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": ">= 12.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
While trying to fix some things in this PR: https://github.com/glimmerjs/glimmer.js/pull/360/checks?check_run_id=3571369240
I noticed that ember no longer supports Node 10

idk if this is the right thing to do -- just trying to unblock PRs atm
