### PR TITLE
Rename .babelrc.js to babel.config.js and enable caching

### DIFF
--- a/packages/@glimmer/blueprint/files/.babelrc.js
+++ b/packages/@glimmer/blueprint/files/.babelrc.js
@@ -1,5 +1,0 @@
-module.exports = function () {
-  return {
-    presets: ['@glimmer/babel-preset', '@babel/preset-env', '@babel/preset-typescript'],
-  };
-};

--- a/packages/@glimmer/blueprint/files/babel.config.js
+++ b/packages/@glimmer/blueprint/files/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['@glimmer/babel-preset', '@babel/preset-env', '@babel/preset-typescript']
+  };
+};


### PR DESCRIPTION
Running the command:
```
npx ember-cli new hello-glimmerx --blueprint @glimmerx/blueprint
```
and then `npm start` in the project resulted in the error:
```
ERROR in ./src/index.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: Caching was left unconfigured. Babel's plugins, presets, and .babelrc.js files can be configured
for various types of caching, using the first param of their handler functions:

module.exports = function(api) {
  // The API exposes the following:

  // Cache the returned value forever and don't call this function again.
  api.cache(true);

  // Don't cache at all. Not recommended because it will be very slow.
  api.cache(false);

  // Cached based on the value of some function. If this function returns a value different from
  // a previously-encountered value, the plugins will re-evaluate.
  var env = api.cache(() => process.env.NODE_ENV);

  // If testing for a specific env, we recommend specifics to avoid instantiating a plugin for
  // any possible NODE_ENV value that might come up during plugin execution.
  var isProd = api.cache(() => process.env.NODE_ENV === "production");

  // .cache(fn) will perform a linear search though instances to find the matching plugin based
  // based on previous instantiated plugins. If you want to recreate the plugin and discard the
  // previous instance whenever something changes, you may use:
  var isProd = api.cache.invalidate(() => process.env.NODE_ENV === "production");

  // Note, we also expose the following more-verbose versions of the above examples:
  api.cache.forever(); // api.cache(true)
  api.cache.never();   // api.cache(false)
  api.cache.using(fn); // api.cache(fn)

  // Return the value that will be cached.
  return { };
};
```

---

This renames the blueprint `.babelrc.js` to `babel.config.js` and enables Babel's cache. The naming feels more consistent with the `webpack.config.js` naming and configuring the cache should avoid this error.