### PR TITLE
Fixing documentation links on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ packages, so this meta-repo exists to help you find what you're looking for.
 
 ## Resources
 
-- [Guides](https://glimmerjs.com/guides)
-- [API Docs](https://glimmerjs.com/api/)
-- [Glimmer Playground](https://glimmer-playground.netlify.com)
+- [Guides](https://github.com/glimmerjs/glimmer-experimental/blob/master/README.md)
+- [Glimmer Playground](https://glimmerjs.github.io/glimmer-experimental)
 
 ## Packages
 


### PR DESCRIPTION
I’ve noticed the main relevant links on this README are pointing to dead links, so I tried to match them with the ones currently being used at https://glimmerjs.com. I couldn’t find a corresponding page for the API docs…

Feel free to close this PR instead, if you just noticed the (old) pages in question are down and you can bring them back up! :)

[edit]
Closes https://github.com/glimmerjs/glimmer.js/issues/330.