### PR TITLE
Fix `Signature` integration for external consumers

### DIFF
--- a/packages/@glimmer/component/addon/-private/component.ts
+++ b/packages/@glimmer/component/addon/-private/component.ts
@@ -68,7 +68,7 @@ type _ExpandSignature<T> = {
   Blocks: 'Blocks' extends keyof T
     ? {
         [Block in keyof T['Blocks']]: T['Blocks'][Block] extends unknown[]
-          ? { Positional: T['Blocks'][Block] }
+          ? { Params: { Positional: T['Blocks'][Block] } }
           : T['Blocks'][Block];
       }
     : EmptyObject;

--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -87,6 +87,13 @@
     "typescript": "~4.2.3",
     "webpack": "^5.69.0"
   },
+  "typesVersions": {
+    "*": {
+      "-private/*": [
+        "dist/modules/addon/-private/*"
+      ]
+    }
+  },
   "engines": {
     "node": "12.* || 14.* || >= 16"
   },

--- a/test/types/component-test.ts
+++ b/test/types/component-test.ts
@@ -9,7 +9,7 @@ import Component from '@glimmer/component';
 // expect to be -- and this keeps us honest about the fact that if we *change*
 // this import location, we've broken any existing declarations published using
 // the current type signatures.
-import { EmptyObject, ExpandSignature } from '@glimmer/component/addon/-private/component';
+import type { EmptyObject, ExpandSignature } from '@glimmer/component/-private/component';
 
 declare let basicComponent: Component;
 expectTypeOf(basicComponent).toHaveProperty('args');

--- a/test/types/component-test.ts
+++ b/test/types/component-test.ts
@@ -9,7 +9,7 @@ import Component from '@glimmer/component';
 // expect to be -- and this keeps us honest about the fact that if we *change*
 // this import location, we've broken any existing declarations published using
 // the current type signatures.
-import { EmptyObject } from '@glimmer/component/addon/-private/component';
+import { EmptyObject, ExpandSignature } from '@glimmer/component/addon/-private/component';
 
 declare let basicComponent: Component;
 expectTypeOf(basicComponent).toHaveProperty('args');
@@ -30,6 +30,12 @@ type LegacyArgs = {
 const componentWithLegacyArgs = new Component<LegacyArgs>({}, { foo: 123 });
 expectTypeOf(componentWithLegacyArgs.args).toEqualTypeOf<Readonly<LegacyArgs>>();
 
+expectTypeOf<ExpandSignature<LegacyArgs>>().toEqualTypeOf<{
+  Args: { Named: LegacyArgs; Positional: [] };
+  Element: null;
+  Blocks: EmptyObject;
+}>();
+
 // Here, we are testing that the types propertly distribute over union types,
 // generics which extend other types, etc.
 // Here, we are testing that the types propertly distribute over union types,
@@ -43,6 +49,19 @@ const legacyArgsDistributiveB = new Component<LegacyArgsDistributive>(
   { bar: 'hello', baz: true }
 );
 expectTypeOf(legacyArgsDistributiveB.args).toEqualTypeOf<Readonly<LegacyArgsDistributive>>();
+
+expectTypeOf<ExpandSignature<LegacyArgsDistributive>>().toEqualTypeOf<
+  | {
+      Args: { Named: { foo: number }; Positional: [] };
+      Element: null;
+      Blocks: EmptyObject;
+    }
+  | {
+      Args: { Named: { bar: string; baz: boolean }; Positional: [] };
+      Element: null;
+      Blocks: EmptyObject;
+    }
+>();
 
 interface ExtensibleLegacy<T> {
   value: T;
@@ -67,6 +86,12 @@ interface ArgsOnly {
 const componentWithArgsOnly = new Component<ArgsOnly>({}, { foo: 123 });
 expectTypeOf(componentWithArgsOnly.args).toEqualTypeOf<Readonly<LegacyArgs>>();
 
+expectTypeOf<ExpandSignature<ArgsOnly>>().toEqualTypeOf<{
+  Args: { Named: LegacyArgs; Positional: [] };
+  Element: null;
+  Blocks: EmptyObject;
+}>();
+
 interface ElementOnly {
   Element: HTMLParagraphElement;
 }
@@ -74,6 +99,12 @@ interface ElementOnly {
 const componentWithElOnly = new Component<ElementOnly>({}, {});
 
 expectTypeOf(componentWithElOnly.args).toEqualTypeOf<Readonly<EmptyObject>>();
+
+expectTypeOf<ExpandSignature<ElementOnly>>().toEqualTypeOf<{
+  Args: { Named: EmptyObject; Positional: [] };
+  Element: HTMLParagraphElement;
+  Blocks: EmptyObject;
+}>();
 
 interface Blocks {
   default: [name: string];
@@ -88,6 +119,23 @@ const componentWithBlockOnly = new Component<BlockOnlySig>({}, {});
 
 expectTypeOf(componentWithBlockOnly.args).toEqualTypeOf<Readonly<EmptyObject>>();
 
+expectTypeOf<ExpandSignature<BlockOnlySig>>().toEqualTypeOf<{
+  Args: { Named: EmptyObject; Positional: [] };
+  Element: null;
+  Blocks: {
+    default: {
+      Params: {
+        Positional: [name: string];
+      };
+    };
+    inverse: {
+      Params: {
+        Positional: [];
+      };
+    };
+  };
+}>();
+
 interface ArgsAndBlocks {
   Args: LegacyArgs;
   Blocks: Blocks;
@@ -95,6 +143,23 @@ interface ArgsAndBlocks {
 
 const componentwithArgsAndBlocks = new Component<ArgsAndBlocks>({}, { foo: 123 });
 expectTypeOf(componentwithArgsAndBlocks.args).toEqualTypeOf<Readonly<LegacyArgs>>();
+
+expectTypeOf<ExpandSignature<ArgsAndBlocks>>().toEqualTypeOf<{
+  Args: { Named: LegacyArgs; Positional: [] };
+  Element: null;
+  Blocks: {
+    default: {
+      Params: {
+        Positional: [name: string];
+      };
+    };
+    inverse: {
+      Params: {
+        Positional: [];
+      };
+    };
+  };
+}>();
 
 interface ArgsAndEl {
   Args: LegacyArgs;
@@ -104,6 +169,12 @@ interface ArgsAndEl {
 const componentwithArgsAndEl = new Component<ArgsAndEl>({}, { foo: 123 });
 expectTypeOf(componentwithArgsAndEl.args).toEqualTypeOf<Readonly<LegacyArgs>>();
 
+expectTypeOf<ExpandSignature<ArgsAndEl>>().toEqualTypeOf<{
+  Args: { Named: LegacyArgs; Positional: [] };
+  Element: HTMLParagraphElement;
+  Blocks: EmptyObject;
+}>();
+
 interface FullShortSig {
   Args: LegacyArgs;
   Element: HTMLParagraphElement;
@@ -112,6 +183,23 @@ interface FullShortSig {
 
 const componentWithFullShortSig = new Component<FullShortSig>({}, { foo: 123 });
 expectTypeOf(componentWithFullShortSig.args).toEqualTypeOf<Readonly<LegacyArgs>>();
+
+expectTypeOf<ExpandSignature<FullShortSig>>().toEqualTypeOf<{
+  Args: { Named: LegacyArgs; Positional: [] };
+  Element: HTMLParagraphElement;
+  Blocks: {
+    default: {
+      Params: {
+        Positional: [name: string];
+      };
+    };
+    inverse: {
+      Params: {
+        Positional: [];
+      };
+    };
+  };
+}>();
 
 interface FullLongSig {
   Args: {
@@ -130,3 +218,5 @@ interface FullLongSig {
 
 const componentWithFullSig = new Component<FullLongSig>({}, { foo: 123 });
 expectTypeOf(componentWithFullSig.args).toEqualTypeOf<Readonly<LegacyArgs>>();
+
+expectTypeOf<ExpandSignature<FullLongSig>>().toEqualTypeOf<FullLongSig>();


### PR DESCRIPTION
There are two hazards currently facing consumers of the mostly-private `ExpandSignature` type that landed in #385.
 - The [Signature RFC](https://github.com/emberjs/rfcs/pull/748) called for a `Params` wrapper around the fully-expanded form of a block definition, which is missing here when the user provides the shorthand
 - v1 and v2 of `@glimmer/component` publish their types in different locations (alone in `dist/types/...` in v1, but alongside the implementation in`dist/{modules,commonjs}/...` in v2)

This PR adds the missing `{ Params: ... }` wrapper and a `typesVersions` entry that will allow for a standardized import path between v1 and v2 for privileged consumers of the `ExpandSignature` type.

I'll also plan to open an equivalent PR to this one against the `v1.x` branch, assuming everything looks ok here.

/cc @chriskrycho 