### PR TITLE
Backport: Fix `Signature` integration for external consumers

### DIFF
--- a/packages/@glimmer/component/addon/-private/component.ts
+++ b/packages/@glimmer/component/addon/-private/component.ts
@@ -62,8 +62,8 @@ type _ExpandSignature<T> = {
   Blocks: T extends { Blocks: infer Blocks }
     ? {
         [Block in keyof Blocks]: Blocks[Block] extends unknown[]
-          ? { Positional: Blocks[Block] }
-          : Blocks[Block]
+          ? { Params: { Positional: Blocks[Block] } }
+          : Blocks[Block];
       }
     : EmptyObject;
 };

--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -85,6 +85,13 @@
     "qunit-dom": "^0.7.1",
     "typescript": "~3.5.3"
   },
+  "typesVersions": {
+    "*": {
+      "-private/*": [
+        "dist/types/addon/-private/*"
+      ]
+    }
+  },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"
   },

--- a/test/types/component-test.ts
+++ b/test/types/component-test.ts
@@ -12,7 +12,10 @@ import Component from '@glimmer/component';
 // matches the actual import location to which this type would be emitted. Since
 // this is an internal-only type whose presence consumers should not rely on and
 // which they should not use in any way, this is "safe" from a public API POV.
-import { EmptyObject } from '@glimmer/component/dist/types/addon/-private/component';
+import {
+  EmptyObject,
+  ExpandSignature,
+} from '@glimmer/component/dist/types/addon/-private/component';
 
 declare let basicComponent: Component;
 expectTypeOf(basicComponent).toHaveProperty('args');
@@ -33,14 +36,36 @@ type LegacyArgs = {
 const componentWithLegacyArgs = new Component<LegacyArgs>({}, { foo: 123 });
 expectTypeOf(componentWithLegacyArgs.args).toEqualTypeOf<Readonly<LegacyArgs>>();
 
+expectTypeOf<ExpandSignature<LegacyArgs>>().toEqualTypeOf<{
+  Args: { Named: LegacyArgs; Positional: [] };
+  Element: null;
+  Blocks: EmptyObject;
+}>();
+
 // Here, we are testing that the types propertly distribute over union types,
 // generics which extend other types, etc.
 type LegacyArgsDistributive = { foo: number } | { bar: string; baz: boolean };
 
 const legacyArgsDistributiveA = new Component<LegacyArgsDistributive>({}, { foo: 123 });
 expectTypeOf(legacyArgsDistributiveA.args).toEqualTypeOf<Readonly<LegacyArgsDistributive>>();
-const legacyArgsDistributiveB = new Component<LegacyArgsDistributive>({}, { bar: "hello", baz: true });
+const legacyArgsDistributiveB = new Component<LegacyArgsDistributive>(
+  {},
+  { bar: 'hello', baz: true }
+);
 expectTypeOf(legacyArgsDistributiveB.args).toEqualTypeOf<Readonly<LegacyArgsDistributive>>();
+
+expectTypeOf<ExpandSignature<LegacyArgsDistributive>>().toEqualTypeOf<
+  | {
+      Args: { Named: { foo: number }; Positional: [] };
+      Element: null;
+      Blocks: EmptyObject;
+    }
+  | {
+      Args: { Named: { bar: string; baz: boolean }; Positional: [] };
+      Element: null;
+      Blocks: EmptyObject;
+    }
+>();
 
 interface ExtensibleLegacy<T> {
   value: T;
@@ -67,6 +92,12 @@ interface ArgsOnly {
 const componentWithArgsOnly = new Component<ArgsOnly>({}, { foo: 123 });
 expectTypeOf(componentWithArgsOnly.args).toEqualTypeOf<Readonly<LegacyArgs>>();
 
+expectTypeOf<ExpandSignature<ArgsOnly>>().toEqualTypeOf<{
+  Args: { Named: LegacyArgs; Positional: [] };
+  Element: null;
+  Blocks: EmptyObject;
+}>();
+
 interface ElementOnly {
   Element: HTMLParagraphElement;
 }
@@ -74,6 +105,12 @@ interface ElementOnly {
 const componentWithElOnly = new Component<ElementOnly>({}, {});
 
 expectTypeOf(componentWithElOnly.args).toEqualTypeOf<Readonly<EmptyObject>>();
+
+expectTypeOf<ExpandSignature<ElementOnly>>().toEqualTypeOf<{
+  Args: { Named: EmptyObject; Positional: [] };
+  Element: HTMLParagraphElement;
+  Blocks: EmptyObject;
+}>();
 
 interface Blocks {
   default: [string];
@@ -88,6 +125,23 @@ const componentWithBlockOnly = new Component<BlockOnlySig>({}, {});
 
 expectTypeOf(componentWithBlockOnly.args).toEqualTypeOf<Readonly<EmptyObject>>();
 
+expectTypeOf<ExpandSignature<BlockOnlySig>>().toEqualTypeOf<{
+  Args: { Named: EmptyObject; Positional: [] };
+  Element: null;
+  Blocks: {
+    default: {
+      Params: {
+        Positional: [string];
+      };
+    };
+    inverse: {
+      Params: {
+        Positional: [];
+      };
+    };
+  };
+}>();
+
 interface ArgsAndBlocks {
   Args: LegacyArgs;
   Blocks: Blocks;
@@ -95,6 +149,23 @@ interface ArgsAndBlocks {
 
 const componentwithArgsAndBlocks = new Component<ArgsAndBlocks>({}, { foo: 123 });
 expectTypeOf(componentwithArgsAndBlocks.args).toEqualTypeOf<Readonly<LegacyArgs>>();
+
+expectTypeOf<ExpandSignature<ArgsAndBlocks>>().toEqualTypeOf<{
+  Args: { Named: LegacyArgs; Positional: [] };
+  Element: null;
+  Blocks: {
+    default: {
+      Params: {
+        Positional: [string];
+      };
+    };
+    inverse: {
+      Params: {
+        Positional: [];
+      };
+    };
+  };
+}>();
 
 interface ArgsAndEl {
   Args: LegacyArgs;
@@ -104,6 +175,12 @@ interface ArgsAndEl {
 const componentwithArgsAndEl = new Component<ArgsAndEl>({}, { foo: 123 });
 expectTypeOf(componentwithArgsAndEl.args).toEqualTypeOf<Readonly<LegacyArgs>>();
 
+expectTypeOf<ExpandSignature<ArgsAndEl>>().toEqualTypeOf<{
+  Args: { Named: LegacyArgs; Positional: [] };
+  Element: HTMLParagraphElement;
+  Blocks: EmptyObject;
+}>();
+
 interface FullShortSig {
   Args: LegacyArgs;
   Element: HTMLParagraphElement;
@@ -112,6 +189,23 @@ interface FullShortSig {
 
 const componentWithFullShortSig = new Component<FullShortSig>({}, { foo: 123 });
 expectTypeOf(componentWithFullShortSig.args).toEqualTypeOf<Readonly<LegacyArgs>>();
+
+expectTypeOf<ExpandSignature<FullShortSig>>().toEqualTypeOf<{
+  Args: { Named: LegacyArgs; Positional: [] };
+  Element: HTMLParagraphElement;
+  Blocks: {
+    default: {
+      Params: {
+        Positional: [string];
+      };
+    };
+    inverse: {
+      Params: {
+        Positional: [];
+      };
+    };
+  };
+}>();
 
 interface FullLongSig {
   Args: {
@@ -130,3 +224,5 @@ interface FullLongSig {
 
 const componentWithFullSig = new Component<FullLongSig>({}, { foo: 123 });
 expectTypeOf(componentWithFullSig.args).toEqualTypeOf<Readonly<LegacyArgs>>();
+
+expectTypeOf<ExpandSignature<FullLongSig>>().toEqualTypeOf<FullLongSig>();

--- a/test/types/component-test.ts
+++ b/test/types/component-test.ts
@@ -12,10 +12,7 @@ import Component from '@glimmer/component';
 // matches the actual import location to which this type would be emitted. Since
 // this is an internal-only type whose presence consumers should not rely on and
 // which they should not use in any way, this is "safe" from a public API POV.
-import {
-  EmptyObject,
-  ExpandSignature,
-} from '@glimmer/component/dist/types/addon/-private/component';
+import { EmptyObject, ExpandSignature } from '@glimmer/component/-private/component';
 
 declare let basicComponent: Component;
 expectTypeOf(basicComponent).toHaveProperty('args');

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -31,6 +31,10 @@
     "noEmit": true,
 
     "paths": {
+      "@glimmer/component/-private/*": [
+        // This must match the `typesVersions` entry in `@glimmer/component`'s package.json
+        "../../dist/@glimmer/component/dist/types/addon/-private/*"
+      ],
       "@glimmer/*": ["../../dist/@glimmer/*"]
     }
   }


### PR DESCRIPTION
This backports #392 to `v1.x`.

The only notable difference is that because of the way types tests on the 1.x branch use `paths` to locate the published packages in `dist`, the type mapping has to exist both in the tests' `tsconfig.json` _and_ in `@glint/component`'s `package.json`.